### PR TITLE
Add C++ IP and MAC address types

### DIFF
--- a/include/etcpal/cpp/inet.h
+++ b/include/etcpal/cpp/inet.h
@@ -37,6 +37,15 @@ namespace etcpal
 /// \brief C++ utilities for the \ref etcpal_inet module.
 
 /// \ingroup etcpal_cpp_inet
+/// \brief An IP address type.
+enum class IpAddrType
+{
+  Invalid = kEtcPalIpTypeInvalid,
+  V4 = kEtcPalIpTypeV4,
+  V6 = kEtcPalIpTypeV6
+};
+
+/// \ingroup etcpal_cpp_inet
 /// \brief A wrapper class for the EtcPal IP address type.
 ///
 /// Provides C++ syntactic sugar for working with IP addresses.
@@ -64,7 +73,7 @@ public:
   unsigned long scope_id() const noexcept;
 
   bool IsValid() const noexcept;
-  etcpal_iptype_t type() const noexcept;
+  IpAddrType type() const noexcept;
   bool IsV4() const noexcept;
   bool IsV6() const noexcept;
   bool IsLinkLocal() const noexcept;
@@ -81,7 +90,7 @@ public:
   static IpAddr FromString(const std::string& ip_str) noexcept;
   static IpAddr WildcardV4() noexcept;
   static IpAddr WildcardV6() noexcept;
-  static IpAddr Wildcard(etcpal_iptype_t type) noexcept;
+  static IpAddr Wildcard(IpAddrType type) noexcept;
 
 private:
   EtcPalIpAddr addr_{};
@@ -196,9 +205,9 @@ inline bool IpAddr::IsValid() const noexcept
 }
 
 /// \brief Get the type of the IP address.
-inline etcpal_iptype_t IpAddr::type() const noexcept
+inline IpAddrType IpAddr::type() const noexcept
 {
-  return addr_.type;
+  return static_cast<IpAddrType>(addr_.type);
 }
 
 /// \brief Whether an IpAddr contains a valid IPv4 address.
@@ -288,7 +297,7 @@ inline IpAddr IpAddr::FromString(const std::string& ip_str) noexcept
 /// See etcpal_ip_set_wildcard() for more information.
 inline IpAddr IpAddr::WildcardV4() noexcept
 {
-  return Wildcard(kEtcPalIpTypeV4);
+  return Wildcard(IpAddrType::V4);
 }
 
 /// \brief Construct a wildcard IPv6 address.
@@ -296,16 +305,16 @@ inline IpAddr IpAddr::WildcardV4() noexcept
 /// See etcpal_ip_set_wildcard() for more information.
 inline IpAddr IpAddr::WildcardV6() noexcept
 {
-  return Wildcard(kEtcPalIpTypeV6);
+  return Wildcard(IpAddrType::V6);
 }
 
 /// \brief Construct a wildcard address of the type specified.
 ///
 /// See etcpal_ip_set_wildcard() for more information.
-inline IpAddr IpAddr::Wildcard(etcpal_iptype_t type) noexcept
+inline IpAddr IpAddr::Wildcard(IpAddrType type) noexcept
 {
   IpAddr result;
-  etcpal_ip_set_wildcard(type, &result.addr_);
+  etcpal_ip_set_wildcard(static_cast<etcpal_iptype_t>(type), &result.addr_);
   return result;
 }
 

--- a/include/etcpal/cpp/inet.h
+++ b/include/etcpal/cpp/inet.h
@@ -1,0 +1,321 @@
+/******************************************************************************
+ * Copyright 2019 ETC Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************
+ * This file is a part of EtcPal. For more information, go to:
+ * https://github.com/ETCLabs/EtcPal
+ ******************************************************************************/
+
+/// \file etcpal/cpp/inet.h
+/// \brief C++ wrapper and utilities for etcpal/inet.h
+
+#ifndef ETCPAL_CPP_INET_H_
+#define ETCPAL_CPP_INET_H_
+
+#include <array>
+#include "etcpal/inet.h"
+
+namespace etcpal
+{
+/// \defgroup etcpal_cpp_inet etcpal_cpp_inet
+/// \ingroup etcpal_cpp
+/// \brief C++ utilities for the \ref etcpal_inet module.
+
+/// \ingroup etcpal_cpp_inet
+/// \brief A wrapper class for the EtcPal IP address type.
+///
+/// Provides C++ syntactic sugar for working with IP addresses.
+class IpAddr
+{
+public:
+  IpAddr();
+  // Note: this constructor is not explicit by design, to allow implicit conversions e.g.
+  //   etcpal::IpAddr ip = etcpal_c_function_that_returns_ip();
+  IpAddr(const EtcPalIpAddr& c_ip);
+  IpAddr& operator=(const EtcPalIpAddr& c_ip);
+
+  IpAddr(uint32_t v4_data);
+  IpAddr(const uint8_t* v6_data);
+  IpAddr(const uint8_t* v6_data, unsigned long scope_id);
+
+  const EtcPalIpAddr& get() const;
+  std::string ToString() const;
+
+  etcpal_iptype_t type() const;
+  uint32_t v4_data() const;
+  const uint8_t* v6_data() const;
+  unsigned long scope_id() const;
+
+  bool IsValid() const;
+  bool IsV4() const;
+  bool IsV6() const;
+  bool IsLinkLocal() const;
+  bool IsLoopback() const;
+  bool IsMulticast() const;
+  bool IsWildcard() const;
+
+  void SetAddress(uint32_t v4_data);
+  void SetAddress(const uint8_t* v6_data);
+
+  static IpAddr FromString(const std::string& ip_str);
+  static IpAddr WildcardV4();
+  static IpAddr WildcardV6();
+  static IpAddr Wildcard(etcpal_iptype_t type);
+
+private:
+  EtcPalIpAddr addr_{};
+};
+
+inline IpAddr::IpAddr()
+{
+  ETCPAL_IP_SET_INVALID(&addr_);
+}
+
+inline IpAddr::IpAddr(const EtcPalIpAddr& c_ip) : addr_(c_ip)
+{
+}
+
+inline IpAddr& IpAddr::operator=(const EtcPalIpAddr& c_ip)
+{
+  addr_ = c_ip;
+  return *this;
+}
+
+inline IpAddr::IpAddr(uint32_t v4_data)
+{
+  ETCPAL_IP_SET_V4_ADDRESS(&addr_, v4_data);
+}
+
+inline IpAddr::IpAddr(const uint8_t* v6_data)
+{
+  ETCPAL_IP_SET_V6_ADDRESS(&addr_, v6_data);
+}
+
+inline const EtcPalIpAddr& IpAddr::get() const
+{
+  return addr_;
+}
+
+inline std::string IpAddr::ToString() const
+{
+  char str_buf[ETCPAL_INET6_ADDRSTRLEN];
+  auto result = etcpal_inet_ntop(&addr_, str_buf, ETCPAL_INET6_ADDRSTRLEN);
+  if (result == kEtcPalErrOk)
+    return str_buf;
+  else
+    return std::string();
+}
+
+inline etcpal_iptype_t IpAddr::type() const
+{
+  return addr_.type;
+}
+
+inline uint32_t IpAddr::v4_data() const
+{
+  return ETCPAL_IP_V4_ADDRESS(&addr_);
+}
+
+inline const uint8_t* IpAddr::v6_data() const
+{
+  return ETCPAL_IP_V6_ADDRESS(&addr_);
+}
+
+inline bool IpAddr::IsValid() const
+{
+  return !ETCPAL_IP_IS_INVALID(&addr_);
+}
+
+inline bool IpAddr::IsV4() const
+{
+  return ETCPAL_IP_IS_V4(&addr_);
+}
+
+inline bool IpAddr::IsV6() const
+{
+  return ETCPAL_IP_IS_V6(&addr_);
+}
+
+inline bool IpAddr::IsLinkLocal() const
+{
+  return etcpal_ip_is_link_local(&addr_);
+}
+
+inline bool IpAddr::IsLoopback() const
+{
+  return etcpal_ip_is_loopback(&addr_);
+}
+
+inline bool IpAddr::IsMulticast() const
+{
+  return etcpal_ip_is_multicast(&addr_);
+}
+
+inline bool IpAddr::IsWildcard() const
+{
+  return etcpal_ip_is_wildcard(&addr_);
+}
+
+inline void IpAddr::SetAddress(uint32_t v4_data)
+{
+  ETCPAL_IP_SET_V4_ADDRESS(&addr_, v4_data);
+}
+
+inline void IpAddr::SetAddress(const uint8_t* v6_data)
+{
+  ETCPAL_IP_SET_V6_ADDRESS(&addr_, v6_data);
+}
+
+inline IpAddr IpAddr::FromString(const std::string& ip_str)
+{
+  IpAddr result;
+  if (etcpal_inet_pton(kEtcPalIpTypeV4, ip_str.c_str(), &result.addr_) != kEtcPalErrOk)
+  {
+    etcpal_inet_pton(kEtcPalIpTypeV6, ip_str.c_str(), &result.addr_);
+  }
+  return result;
+}
+
+inline IpAddr IpAddr::WildcardV4()
+{
+  return Wildcard(kEtcPalIpTypeV4);
+}
+
+inline IpAddr IpAddr::WildcardV6()
+{
+  return Wildcard(kEtcPalIpTypeV6);
+}
+
+inline IpAddr IpAddr::Wildcard(etcpal_iptype_t type)
+{
+  IpAddr result;
+  etcpal_ip_set_wildcard(type, &result.addr_);
+  return result;
+}
+
+/// \ingroup etcpal_cpp_inet
+/// \brief A wrapper for the EtcPal socket address type.
+///
+/// Provides C++ syntactic sugar for working with socket addresses, which contain an IP address and
+/// port.
+class SockAddr
+{
+public:
+  SockAddr();
+  // Note: this constructor is not explicit by design, to allow implicit conversions e.g.
+  //   etcpal::SockAddr sa = etcpal_c_function_that_returns_sockaddr();
+  SockAddr(const EtcPalSockAddr& c_sa);
+  SockAddr& operator=(const EtcPalSockAddr& c_sa);
+
+  SockAddr(uint32_t v4_data, uint16_t port);
+  SockAddr(const uint8_t* v6_data, uint16_t port);
+
+  const EtcPalSockAddr& get() const;
+  IpAddr ip();
+  uint16_t port();
+
+private:
+  EtcPalSockAddr addr_{};
+};
+
+inline SockAddr::SockAddr()
+{
+  ETCPAL_IP_SET_INVALID(&addr_.ip);
+}
+
+/// \ingroup etcpal_cpp_inet
+/// \brief A wrapper for the EtcPal MAC address type.
+///
+/// Provides C++ syntactic sugar for working with MAC addresses.
+class MacAddr
+{
+public:
+  MacAddr() = default;
+  MacAddr(const EtcPalMacAddr& c_mac);
+  MacAddr& operator=(const EtcPalMacAddr& c_mac);
+
+  const EtcPalMacAddr& get() const;
+  const std::array<uint8_t, ETCPAL_MAC_BYTES> ToArray() const;
+  std::string ToString() const;
+
+private:
+  EtcPalMacAddr addr_{};
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Operators
+////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/// \addtogroup etcpal_cpp_inet
+/// @{
+
+// Special operators for comparing with EtcPalIpAddrs
+
+inline bool operator==(const EtcPalIpAddr& c_ip, const IpAddr& ip) noexcept
+{
+  return c_ip == ip.get();
+}
+
+inline bool operator!=(const EtcPalIpAddr& c_ip, const IpAddr& ip) noexcept
+{
+  return !(c_ip == ip);
+}
+
+inline bool operator==(const IpAddr& ip, const EtcPalIpAddr& c_ip) noexcept
+{
+  return ip.get() == c_ip;
+}
+
+inline bool operator!=(const IpAddr& ip, const EtcPalIpAddr& c_ip) noexcept
+{
+  return !(ip == c_ip);
+}
+
+// Standard operators
+
+inline bool operator==(const IpAddr& a, const IpAddr& b) noexcept
+{
+  return a.get() == b.get();
+}
+
+inline bool operator!=(const IpAddr& a, const IpAddr& b) noexcept
+{
+  return !(a == b);
+}
+
+inline bool operator<(const IpAddr& a, const IpAddr& b) noexcept
+{
+  return a.get() < b.get();
+}
+
+inline bool operator>(const IpAddr& a, const IpAddr& b) noexcept
+{
+  return b < a;
+}
+
+inline bool operator<=(const IpAddr& a, const IpAddr& b) noexcept
+{
+  return !(b < a);
+}
+
+inline bool operator>=(const IpAddr& a, const IpAddr& b) noexcept
+{
+  return !(a < b);
+}
+
+/// @}
+
+};  // namespace etcpal
+
+#endif  // ETCPAL_CPP_LOCK_H_

--- a/include/etcpal/cpp/inet.h
+++ b/include/etcpal/cpp/inet.h
@@ -52,8 +52,6 @@ public:
   IpAddr(uint32_t v4_data) noexcept;
   explicit IpAddr(const uint8_t* v6_data) noexcept;
   IpAddr(const uint8_t* v6_data, unsigned long scope_id) noexcept;
-  explicit IpAddr(const std::array<uint8_t, ETCPAL_IPV6_BYTES>& v6_data) noexcept;
-  IpAddr(const std::array<uint8_t, ETCPAL_IPV6_BYTES>& v6_data, unsigned long scope_id) noexcept;
 
   const EtcPalIpAddr& get() const noexcept;
   EtcPalIpAddr& get() noexcept;
@@ -75,8 +73,6 @@ public:
   void SetAddress(uint32_t v4_data) noexcept;
   void SetAddress(const uint8_t* v6_data) noexcept;
   void SetAddress(const uint8_t* v6_data, unsigned long scope_id) noexcept;
-  void SetAddress(const std::array<uint8_t, ETCPAL_IPV6_BYTES>& v6_data) noexcept;
-  void SetAddress(const std::array<uint8_t, ETCPAL_IPV6_BYTES>& v6_data, unsigned long scope_id) noexcept;
 
   static IpAddr FromString(const std::string& ip_str) noexcept;
   static IpAddr WildcardV4() noexcept;
@@ -326,8 +322,6 @@ public:
   SockAddr(uint32_t v4_data, uint16_t port) noexcept;
   SockAddr(const uint8_t* v6_data, uint16_t port) noexcept;
   SockAddr(const uint8_t* v6_data, unsigned long scope_id, uint16_t port) noexcept;
-  SockAddr(const std::array<uint8_t, ETCPAL_IPV6_BYTES>& v6_data, uint16_t port) noexcept;
-  SockAddr(const std::array<uint8_t, ETCPAL_IPV6_BYTES>& v6_data, unsigned long scope_id, uint16_t port) noexcept;
   SockAddr(IpAddr ip, uint16_t port) noexcept;
 
   const EtcPalSockAddr& get() const noexcept;
@@ -335,6 +329,12 @@ public:
   std::string ToString() const;
   IpAddr ip() const noexcept;
   uint16_t port() const noexcept;
+
+  void SetAddress(uint32_t v4_data) noexcept;
+  void SetAddress(const uint8_t* v6_data) noexcept;
+  void SetAddress(const uint8_t* v6_data, unsigned long scope_id) noexcept;
+  void SetAddress(const IpAddr& ip) noexcept;
+  void SetPort(uint16_t port) noexcept;
 
 private:
   EtcPalSockAddr addr_{};
@@ -422,6 +422,31 @@ inline IpAddr SockAddr::ip() const noexcept
 inline uint16_t SockAddr::port() const noexcept
 {
   return addr_.port;
+}
+
+inline void SockAddr::SetAddress(uint32_t v4_data) noexcept
+{
+  ETCPAL_IP_SET_V4_ADDRESS(&addr_.ip, v4_data);
+}
+
+inline void SockAddr::SetAddress(const uint8_t* v6_data) noexcept
+{
+  ETCPAL_IP_SET_V6_ADDRESS(&addr_.ip, v6_data);
+}
+
+inline void SockAddr::SetAddress(const uint8_t* v6_data, unsigned long scope_id) noexcept
+{
+  ETCPAL_IP_SET_V6_ADDRESS_WITH_SCOPE_ID(&addr_.ip, v6_data, scope_id);
+}
+
+inline void SockAddr::SetAddress(const IpAddr& ip) noexcept
+{
+  addr_.ip = ip.get();
+}
+
+inline void SockAddr::SetPort(uint16_t port) noexcept
+{
+  addr_.port = port;
 }
 
 /// \ingroup etcpal_cpp_inet

--- a/include/etcpal/cpp/inet.h
+++ b/include/etcpal/cpp/inet.h
@@ -50,13 +50,17 @@ public:
   IpAddr& operator=(const EtcPalIpAddr& c_ip) noexcept;
 
   IpAddr(uint32_t v4_data) noexcept;
-  IpAddr(const uint8_t* v6_data) noexcept;
+  explicit IpAddr(const uint8_t* v6_data) noexcept;
   IpAddr(const uint8_t* v6_data, unsigned long scope_id) noexcept;
+  explicit IpAddr(const std::array<uint8_t, ETCPAL_IPV6_BYTES>& v6_data) noexcept;
+  IpAddr(const std::array<uint8_t, ETCPAL_IPV6_BYTES>& v6_data, unsigned long scope_id) noexcept;
 
   const EtcPalIpAddr& get() const noexcept;
+  EtcPalIpAddr& get() noexcept;
   std::string ToString() const;
   uint32_t v4_data() const noexcept;
   const uint8_t* v6_data() const noexcept;
+  std::array<uint8_t, ETCPAL_IPV6_BYTES> ToV6Array() const;
   unsigned long scope_id() const noexcept;
 
   bool IsValid() const noexcept;
@@ -124,8 +128,14 @@ inline IpAddr::IpAddr(const uint8_t* v6_data, unsigned long scope_id) noexcept
   ETCPAL_IP_SET_V6_ADDRESS_WITH_SCOPE_ID(&addr_, v6_data, scope_id);
 }
 
-/// \brief Get a reference to the underlying C type.
+/// \brief Get a const reference to the underlying C type.
 inline const EtcPalIpAddr& IpAddr::get() const noexcept
+{
+  return addr_;
+}
+
+/// \brief Get a mutable reference to the underlying C type.
+inline EtcPalIpAddr& IpAddr::get() noexcept
 {
   return addr_;
 }
@@ -313,9 +323,13 @@ public:
 
   SockAddr(uint32_t v4_data, uint16_t port) noexcept;
   SockAddr(const uint8_t* v6_data, uint16_t port) noexcept;
+  SockAddr(const uint8_t* v6_data, unsigned long scope_id, uint16_t port) noexcept;
+  SockAddr(const std::array<uint8_t, ETCPAL_IPV6_BYTES>& v6_data, uint16_t port) noexcept;
+  SockAddr(const std::array<uint8_t, ETCPAL_IPV6_BYTES>& v6_data, unsigned long scope_id, uint16_t port) noexcept;
   SockAddr(IpAddr ip, uint16_t port) noexcept;
 
   const EtcPalSockAddr& get() const noexcept;
+  EtcPalSockAddr& get() noexcept;
   std::string ToString() const;
   IpAddr ip() const noexcept;
   uint16_t port() const noexcept;
@@ -369,8 +383,14 @@ inline SockAddr::SockAddr(IpAddr ip, uint16_t port) noexcept
   addr_.port = port;
 }
 
-/// \brief Get a reference to the underlying C type.
+/// \brief Get a const reference to the underlying C type.
 inline const EtcPalSockAddr& SockAddr::get() const noexcept
+{
+  return addr_;
+}
+
+/// \brief Get a mutable reference to the underlying C type.
+inline EtcPalSockAddr& SockAddr::get() noexcept
 {
   return addr_;
 }
@@ -416,10 +436,13 @@ public:
   MacAddr(const EtcPalMacAddr& c_mac) noexcept;
   MacAddr& operator=(const EtcPalMacAddr& c_mac) noexcept;
   explicit MacAddr(const uint8_t* mac_data) noexcept;
+  explicit MacAddr(const std::array<uint8_t, ETCPAL_MAC_BYTES>& mac_data) noexcept;
 
   const EtcPalMacAddr& get() const noexcept;
+  EtcPalMacAddr& get() noexcept;
   std::string ToString() const;
   const uint8_t* data() const noexcept;
+  std::array<uint8_t, ETCPAL_MAC_BYTES> ToArray() const noexcept;
 
   bool IsNull() const noexcept;
 
@@ -448,8 +471,14 @@ inline MacAddr::MacAddr(const uint8_t* mac_data) noexcept
   std::memcpy(addr_.data, mac_data, ETCPAL_MAC_BYTES);
 }
 
-/// \brief Get a reference to the underlying C type.
+/// \brief Get a const reference to the underlying C type.
 inline const EtcPalMacAddr& MacAddr::get() const noexcept
+{
+  return addr_;
+}
+
+/// \brief Get a mutable reference to the underlying C type.
+inline EtcPalMacAddr& MacAddr::get() noexcept
 {
   return addr_;
 }
@@ -474,10 +503,7 @@ inline const uint8_t* MacAddr::data() const noexcept
 /// \brief Whether this MacAddr represents a null (all 0's) MAC address.
 inline bool MacAddr::IsNull() const noexcept
 {
-  return std::all_of(std::begin(addr_.data), std::end(addr_.data), [](uint8_t byte) { return byte == 0; });
-  // TODO would this be a better implementation?
-  // std::array<uint8_t, ETCPAL_MAC_BYTES> null_mac{};
-  // return (std::memcmp(addr_.data, null_mac.data(), ETCPAL_MAC_BYTES) == 0);
+  return ETCPAL_MAC_IS_NULL(&addr_);
 }
 
 /// \brief Construct a MacAddr from a string representation.

--- a/include/etcpal/cpp/inet.h
+++ b/include/etcpal/cpp/inet.h
@@ -23,7 +23,11 @@
 #ifndef ETCPAL_CPP_INET_H_
 #define ETCPAL_CPP_INET_H_
 
+#include <algorithm>
 #include <array>
+#include <cstring>
+#include <iterator>
+#include <string>
 #include "etcpal/inet.h"
 
 namespace etcpal
@@ -39,74 +43,96 @@ namespace etcpal
 class IpAddr
 {
 public:
-  IpAddr();
+  IpAddr() noexcept;
   // Note: this constructor is not explicit by design, to allow implicit conversions e.g.
   //   etcpal::IpAddr ip = etcpal_c_function_that_returns_ip();
-  IpAddr(const EtcPalIpAddr& c_ip);
-  IpAddr& operator=(const EtcPalIpAddr& c_ip);
+  IpAddr(const EtcPalIpAddr& c_ip) noexcept;
+  IpAddr& operator=(const EtcPalIpAddr& c_ip) noexcept;
 
-  IpAddr(uint32_t v4_data);
-  IpAddr(const uint8_t* v6_data);
-  IpAddr(const uint8_t* v6_data, unsigned long scope_id);
+  IpAddr(uint32_t v4_data) noexcept;
+  IpAddr(const uint8_t* v6_data) noexcept;
+  IpAddr(const uint8_t* v6_data, unsigned long scope_id) noexcept;
 
-  const EtcPalIpAddr& get() const;
+  const EtcPalIpAddr& get() const noexcept;
   std::string ToString() const;
+  uint32_t v4_data() const noexcept;
+  const uint8_t* v6_data() const noexcept;
+  unsigned long scope_id() const noexcept;
 
-  etcpal_iptype_t type() const;
-  uint32_t v4_data() const;
-  const uint8_t* v6_data() const;
-  unsigned long scope_id() const;
+  bool IsValid() const noexcept;
+  etcpal_iptype_t type() const noexcept;
+  bool IsV4() const noexcept;
+  bool IsV6() const noexcept;
+  bool IsLinkLocal() const noexcept;
+  bool IsLoopback() const noexcept;
+  bool IsMulticast() const noexcept;
+  bool IsWildcard() const noexcept;
 
-  bool IsValid() const;
-  bool IsV4() const;
-  bool IsV6() const;
-  bool IsLinkLocal() const;
-  bool IsLoopback() const;
-  bool IsMulticast() const;
-  bool IsWildcard() const;
+  void SetAddress(uint32_t v4_data) noexcept;
+  void SetAddress(const uint8_t* v6_data) noexcept;
+  void SetAddress(const uint8_t* v6_data, unsigned long scope_id) noexcept;
 
-  void SetAddress(uint32_t v4_data);
-  void SetAddress(const uint8_t* v6_data);
-
-  static IpAddr FromString(const std::string& ip_str);
-  static IpAddr WildcardV4();
-  static IpAddr WildcardV6();
-  static IpAddr Wildcard(etcpal_iptype_t type);
+  static IpAddr FromString(const std::string& ip_str) noexcept;
+  static IpAddr WildcardV4() noexcept;
+  static IpAddr WildcardV6() noexcept;
+  static IpAddr Wildcard(etcpal_iptype_t type) noexcept;
 
 private:
   EtcPalIpAddr addr_{};
 };
 
-inline IpAddr::IpAddr()
+/// \brief Constructs an invalid IP address by default.
+inline IpAddr::IpAddr() noexcept
 {
   ETCPAL_IP_SET_INVALID(&addr_);
 }
 
-inline IpAddr::IpAddr(const EtcPalIpAddr& c_ip) : addr_(c_ip)
+/// \brief Construct an IP address copied from an instance of the C EtcPalIpAddr type.
+inline IpAddr::IpAddr(const EtcPalIpAddr& c_ip) noexcept : addr_(c_ip)
 {
 }
 
-inline IpAddr& IpAddr::operator=(const EtcPalIpAddr& c_ip)
+/// \brief Assign an instance of the C EtcPalIpAddr type to an instance of this class.
+inline IpAddr& IpAddr::operator=(const EtcPalIpAddr& c_ip) noexcept
 {
   addr_ = c_ip;
   return *this;
 }
 
-inline IpAddr::IpAddr(uint32_t v4_data)
+/// \brief Construct an IPv4 address from its raw 32-bit representation.
+/// \param[in] v4_data The address data in host byte order.
+inline IpAddr::IpAddr(uint32_t v4_data) noexcept
 {
   ETCPAL_IP_SET_V4_ADDRESS(&addr_, v4_data);
 }
 
-inline IpAddr::IpAddr(const uint8_t* v6_data)
+/// \brief Construct an IPv6 address from its raw 16-byte array representation.
+/// \param[in] v6_data Pointer to the address data, an array of length #ETCPAL_IPV6_BYTES.
+inline IpAddr::IpAddr(const uint8_t* v6_data) noexcept
 {
   ETCPAL_IP_SET_V6_ADDRESS(&addr_, v6_data);
 }
 
-inline const EtcPalIpAddr& IpAddr::get() const
+/// \brief Construct an IPv6 address from its raw 16-bytes array representation and scope ID.
+///
+/// See scope_id() for more information.
+///
+/// \param[in] v6_data Pointer to the address data, an array of length #ETCPAL_IPV6_BYTES.
+/// \param[in] scope_id The address's scope ID.
+inline IpAddr::IpAddr(const uint8_t* v6_data, unsigned long scope_id) noexcept
+{
+  ETCPAL_IP_SET_V6_ADDRESS_WITH_SCOPE_ID(&addr_, v6_data, scope_id);
+}
+
+/// \brief Get a reference to the underlying C type.
+inline const EtcPalIpAddr& IpAddr::get() const noexcept
 {
   return addr_;
 }
 
+/// \brief Convert the IP address to a string representation.
+///
+/// See etcpal_inet_ntop() for more information.
 inline std::string IpAddr::ToString() const
 {
   char str_buf[ETCPAL_INET6_ADDRSTRLEN];
@@ -117,67 +143,125 @@ inline std::string IpAddr::ToString() const
     return std::string();
 }
 
-inline etcpal_iptype_t IpAddr::type() const
-{
-  return addr_.type;
-}
-
-inline uint32_t IpAddr::v4_data() const
+/// \brief Get the raw 32-bit representation of an IPv4 address.
+///
+/// This function will return undefined data if the IpAddr's type is V6 or Invalid.
+///
+/// \return The address data in host byte order.
+inline uint32_t IpAddr::v4_data() const noexcept
 {
   return ETCPAL_IP_V4_ADDRESS(&addr_);
 }
 
-inline const uint8_t* IpAddr::v6_data() const
+/// \brief Get the raw 16-byte array representation of an IPv6 address.
+///
+/// This function will return undefined data if the IpAddr's type is V4 or Invalid.
+///
+/// \return Pointer to an array of length #ETCPAL_IPV6_BYTES containing the address data.
+inline const uint8_t* IpAddr::v6_data() const noexcept
 {
   return ETCPAL_IP_V6_ADDRESS(&addr_);
 }
 
-inline bool IpAddr::IsValid() const
+/// \brief Get the scope ID of an IPv6 address.
+///
+/// Scope IDs (sometimes referred to as Zone IDs or Zone Indices) are a lightly-documented portion
+/// of IPv6 addressing, but one concrete use is to indicate the network interface index of a
+/// link-local IPv6 address. See also \ref interface_indexes.
+///
+/// This function will return undefined data if the IpAddr's type is V4 or Invalid.
+///
+/// \return The scope ID.
+inline unsigned long IpAddr::scope_id() const noexcept
+{
+  return addr_.addr.v6.scope_id;
+}
+
+/// \brief Whether an IpAddr contains a valid IPv4 or IPv6 address.
+inline bool IpAddr::IsValid() const noexcept
 {
   return !ETCPAL_IP_IS_INVALID(&addr_);
 }
 
-inline bool IpAddr::IsV4() const
+/// \brief Get the type of the IP address.
+inline etcpal_iptype_t IpAddr::type() const noexcept
+{
+  return addr_.type;
+}
+
+/// \brief Whether an IpAddr contains a valid IPv4 address.
+inline bool IpAddr::IsV4() const noexcept
 {
   return ETCPAL_IP_IS_V4(&addr_);
 }
 
-inline bool IpAddr::IsV6() const
+/// \brief Whether an IpAddr contains a valid IPv6 address.
+inline bool IpAddr::IsV6() const noexcept
 {
   return ETCPAL_IP_IS_V6(&addr_);
 }
 
-inline bool IpAddr::IsLinkLocal() const
+/// \brief Whether an IpAddr contains a link-local address.
+inline bool IpAddr::IsLinkLocal() const noexcept
 {
   return etcpal_ip_is_link_local(&addr_);
 }
 
-inline bool IpAddr::IsLoopback() const
+/// \brief Whether an IpAddr contains a loopback address.
+inline bool IpAddr::IsLoopback() const noexcept
 {
   return etcpal_ip_is_loopback(&addr_);
 }
 
-inline bool IpAddr::IsMulticast() const
+/// \brief Whether an IpAddr contains a multicast address.
+inline bool IpAddr::IsMulticast() const noexcept
 {
   return etcpal_ip_is_multicast(&addr_);
 }
 
-inline bool IpAddr::IsWildcard() const
+/// \brief Whether an IpAddr contains a multicast address.
+///
+/// See etcpal_ip_is_wildcard() for more information.
+inline bool IpAddr::IsWildcard() const noexcept
 {
   return etcpal_ip_is_wildcard(&addr_);
 }
 
-inline void IpAddr::SetAddress(uint32_t v4_data)
+/// \brief Set the IPv4 address data.
+///
+/// Automatically converts this address's type to V4.
+///
+/// \param[in] v4_data The address data in host byte order.
+inline void IpAddr::SetAddress(uint32_t v4_data) noexcept
 {
   ETCPAL_IP_SET_V4_ADDRESS(&addr_, v4_data);
 }
 
-inline void IpAddr::SetAddress(const uint8_t* v6_data)
+/// \brief Set the IPv6 address data.
+///
+/// Automatically converts this address's type to V6.
+///
+/// \param[in] v6_data Pointer to the address data, an array of length #ETCPAL_IPV6_BYTES.
+inline void IpAddr::SetAddress(const uint8_t* v6_data) noexcept
 {
   ETCPAL_IP_SET_V6_ADDRESS(&addr_, v6_data);
 }
 
-inline IpAddr IpAddr::FromString(const std::string& ip_str)
+/// \brief Set the IPv6 address data and scope ID.
+///
+/// See scope_id() for more information.
+///
+/// \param[in] v6_data Pointer to the address data, an array of length #ETCPAL_IPV6_BYTES.
+/// \param[in] scope_id The address's scope ID.
+inline void IpAddr::SetAddress(const uint8_t* v6_data, unsigned long scope_id) noexcept
+{
+  ETCPAL_IP_SET_V6_ADDRESS_WITH_SCOPE_ID(&addr_, v6_data, scope_id);
+}
+
+/// \brief Construct an IpAddr from a string representation.
+///
+/// See etcpal_inet_pton() for more information.
+inline IpAddr IpAddr::FromString(const std::string& ip_str) noexcept
 {
   IpAddr result;
   if (etcpal_inet_pton(kEtcPalIpTypeV4, ip_str.c_str(), &result.addr_) != kEtcPalErrOk)
@@ -187,17 +271,26 @@ inline IpAddr IpAddr::FromString(const std::string& ip_str)
   return result;
 }
 
-inline IpAddr IpAddr::WildcardV4()
+/// \brief Construct a wildcard IPv4 address.
+///
+/// See etcpal_ip_set_wildcard() for more information.
+inline IpAddr IpAddr::WildcardV4() noexcept
 {
   return Wildcard(kEtcPalIpTypeV4);
 }
 
-inline IpAddr IpAddr::WildcardV6()
+/// \brief Construct a wildcard IPv6 address.
+///
+/// See etcpal_ip_set_wildcard() for more information.
+inline IpAddr IpAddr::WildcardV6() noexcept
 {
   return Wildcard(kEtcPalIpTypeV6);
 }
 
-inline IpAddr IpAddr::Wildcard(etcpal_iptype_t type)
+/// \brief Construct a wildcard address of the type specified.
+///
+/// See etcpal_ip_set_wildcard() for more information.
+inline IpAddr IpAddr::Wildcard(etcpal_iptype_t type) noexcept
 {
   IpAddr result;
   etcpal_ip_set_wildcard(type, &result.addr_);
@@ -212,26 +305,101 @@ inline IpAddr IpAddr::Wildcard(etcpal_iptype_t type)
 class SockAddr
 {
 public:
-  SockAddr();
+  SockAddr() noexcept;
   // Note: this constructor is not explicit by design, to allow implicit conversions e.g.
   //   etcpal::SockAddr sa = etcpal_c_function_that_returns_sockaddr();
-  SockAddr(const EtcPalSockAddr& c_sa);
-  SockAddr& operator=(const EtcPalSockAddr& c_sa);
+  SockAddr(const EtcPalSockAddr& c_sa) noexcept;
+  SockAddr& operator=(const EtcPalSockAddr& c_sa) noexcept;
 
-  SockAddr(uint32_t v4_data, uint16_t port);
-  SockAddr(const uint8_t* v6_data, uint16_t port);
+  SockAddr(uint32_t v4_data, uint16_t port) noexcept;
+  SockAddr(const uint8_t* v6_data, uint16_t port) noexcept;
+  SockAddr(IpAddr ip, uint16_t port) noexcept;
 
-  const EtcPalSockAddr& get() const;
-  IpAddr ip();
-  uint16_t port();
+  const EtcPalSockAddr& get() const noexcept;
+  std::string ToString() const;
+  IpAddr ip() const noexcept;
+  uint16_t port() const noexcept;
 
 private:
   EtcPalSockAddr addr_{};
 };
 
-inline SockAddr::SockAddr()
+/// \brief Constructs an invalid SockAddr by default.
+inline SockAddr::SockAddr() noexcept
 {
   ETCPAL_IP_SET_INVALID(&addr_.ip);
+}
+
+/// \brief Construct a SockAddr copied from an instance of the C EtcPalSockAddr type.
+inline SockAddr::SockAddr(const EtcPalSockAddr& c_sa) noexcept : addr_(c_sa)
+{
+}
+
+/// \brief Assign an instance of the C EtcPalSockAddr type to an instance of this class.
+inline SockAddr& SockAddr::operator=(const EtcPalSockAddr& c_sa) noexcept
+{
+  addr_ = c_sa;
+  return *this;
+}
+
+/// \brief Construct a SockAddr from a raw 32-bit IPv4 representation and port number.
+/// \param[in] v4_data The address data in host byte order.
+/// \param[in] port The port number in host byte order.
+inline SockAddr::SockAddr(uint32_t v4_data, uint16_t port) noexcept
+{
+  ETCPAL_IP_SET_V4_ADDRESS(&addr_.ip, v4_data);
+  addr_.port = port;
+}
+
+/// \brief Construct a SockAddr from a raw 16-byte IPv6 representation and port number.
+/// \param[in] v6_data Pointer to the address data, an array of length #ETCPAL_IPV6_BYTES.
+/// \param[in] port The port number in host byte order.
+inline SockAddr::SockAddr(const uint8_t* v6_data, uint16_t port) noexcept
+{
+  ETCPAL_IP_SET_V6_ADDRESS(&addr_.ip, v6_data);
+  addr_.port = port;
+}
+
+/// \brief Construct a SockAddr from an IpAddr and port number.
+/// \param[in] ip The IP address.
+/// \param[in] port The port number in host byte order.
+inline SockAddr::SockAddr(IpAddr ip, uint16_t port) noexcept
+{
+  addr_.ip = ip.get();
+  addr_.port = port;
+}
+
+/// \brief Get a reference to the underlying C type.
+inline const EtcPalSockAddr& SockAddr::get() const noexcept
+{
+  return addr_;
+}
+
+/// \brief Convert the IP address and port to a string representation.
+///
+/// The string will be of the form ddd.ddd.ddd.ddd:ppppp for IPv4 addresses, and
+/// [xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx:xxxx]:ppppp for IPv6 addresses (common conventions and
+/// rules for compressing these representations will also apply).
+inline std::string SockAddr::ToString() const
+{
+  if (ETCPAL_IP_IS_V4(&addr_.ip))
+    return ip().ToString() + ':' + std::to_string(addr_.port);
+  else if (ETCPAL_IP_IS_V6(&addr_.ip))
+    return '[' + ip().ToString() + "]:" + std::to_string(addr_.port);
+  else
+    return std::string();
+}
+
+/// \brief Get the IP address from the SockAddr.
+inline IpAddr SockAddr::ip() const noexcept
+{
+  return addr_.ip;
+}
+
+/// \brief Get the port number from the SockAddr.
+inline uint16_t SockAddr::port() const noexcept
+{
+  return addr_.port;
 }
 
 /// \ingroup etcpal_cpp_inet
@@ -241,17 +409,86 @@ inline SockAddr::SockAddr()
 class MacAddr
 {
 public:
+  /// \brief Constructs a null MAC address by default.
   MacAddr() = default;
-  MacAddr(const EtcPalMacAddr& c_mac);
-  MacAddr& operator=(const EtcPalMacAddr& c_mac);
+  // Note: this constructor is not explicit by design, to allow implicit conversions e.g.
+  //   etcpal::MacAddr sa = etcpal_c_function_that_returns_macaddr();
+  MacAddr(const EtcPalMacAddr& c_mac) noexcept;
+  MacAddr& operator=(const EtcPalMacAddr& c_mac) noexcept;
+  explicit MacAddr(const uint8_t* mac_data) noexcept;
 
-  const EtcPalMacAddr& get() const;
-  const std::array<uint8_t, ETCPAL_MAC_BYTES> ToArray() const;
+  const EtcPalMacAddr& get() const noexcept;
   std::string ToString() const;
+  const uint8_t* data() const noexcept;
+
+  bool IsNull() const noexcept;
+
+  static MacAddr FromString(const std::string& mac_str) noexcept;
 
 private:
   EtcPalMacAddr addr_{};
 };
+
+/// \brief Construct a MAC address copied from an instance of the C EtcPalMacAddr type.
+inline MacAddr::MacAddr(const EtcPalMacAddr& c_mac) noexcept : addr_(c_mac)
+{
+}
+
+/// \brief Assign an instance of the C EtcPalMacAddr type to an instance of this class.
+inline MacAddr& MacAddr::operator=(const EtcPalMacAddr& c_mac) noexcept
+{
+  addr_ = c_mac;
+  return *this;
+}
+
+/// \brief Construct a MAC address from its raw 6-byte array representation.
+/// \param[in] mac_data Pointer to the MAC data, an array of length #ETCPAL_MAC_BYTES.
+inline MacAddr::MacAddr(const uint8_t* mac_data) noexcept
+{
+  std::memcpy(addr_.data, mac_data, ETCPAL_MAC_BYTES);
+}
+
+/// \brief Get a reference to the underlying C type.
+inline const EtcPalMacAddr& MacAddr::get() const noexcept
+{
+  return addr_;
+}
+
+/// \brief Convert the MAC address to a string representation.
+///
+/// See etcpal_mac_to_string() for more information.
+inline std::string MacAddr::ToString() const
+{
+  char str_buf[ETCPAL_MAC_STRING_BYTES];
+  etcpal_mac_to_string(&addr_, str_buf, ETCPAL_MAC_STRING_BYTES);
+  return str_buf;
+}
+
+/// \brief Get the raw 6-byte array representation of a MAC address.
+/// \return Pointer to an array of length #ETCPAL_MAC_BYTES containing the address data.
+inline const uint8_t* MacAddr::data() const noexcept
+{
+  return addr_.data;
+}
+
+/// \brief Whether this MacAddr represents a null (all 0's) MAC address.
+inline bool MacAddr::IsNull() const noexcept
+{
+  return std::all_of(std::begin(addr_.data), std::end(addr_.data), [](uint8_t byte) { return byte == 0; });
+  // TODO would this be a better implementation?
+  // std::array<uint8_t, ETCPAL_MAC_BYTES> null_mac{};
+  // return (std::memcmp(addr_.data, null_mac.data(), ETCPAL_MAC_BYTES) == 0);
+}
+
+/// \brief Construct a MacAddr from a string representation.
+///
+/// See etcpal_string_to_mac() for more information.
+inline MacAddr MacAddr::FromString(const std::string& mac_str) noexcept
+{
+  MacAddr result;
+  etcpal_string_to_mac(mac_str.c_str(), &result.addr_);
+  return result;
+}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Operators
@@ -260,7 +497,7 @@ private:
 /// \addtogroup etcpal_cpp_inet
 /// @{
 
-// Special operators for comparing with EtcPalIpAddrs
+// Special operators for comparing with the underlying types
 
 inline bool operator==(const EtcPalIpAddr& c_ip, const IpAddr& ip) noexcept
 {
@@ -280,6 +517,46 @@ inline bool operator==(const IpAddr& ip, const EtcPalIpAddr& c_ip) noexcept
 inline bool operator!=(const IpAddr& ip, const EtcPalIpAddr& c_ip) noexcept
 {
   return !(ip == c_ip);
+}
+
+inline bool operator==(const EtcPalSockAddr& c_ip, const SockAddr& ip) noexcept
+{
+  return c_ip == ip.get();
+}
+
+inline bool operator!=(const EtcPalSockAddr& c_ip, const SockAddr& ip) noexcept
+{
+  return !(c_ip == ip);
+}
+
+inline bool operator==(const SockAddr& ip, const EtcPalSockAddr& c_ip) noexcept
+{
+  return ip.get() == c_ip;
+}
+
+inline bool operator!=(const SockAddr& ip, const EtcPalSockAddr& c_ip) noexcept
+{
+  return !(ip == c_ip);
+}
+
+inline bool operator==(const EtcPalMacAddr& c_mac, const MacAddr& mac) noexcept
+{
+  return c_mac == mac.get();
+}
+
+inline bool operator!=(const EtcPalMacAddr& c_mac, const MacAddr& mac) noexcept
+{
+  return !(c_mac == mac);
+}
+
+inline bool operator==(const MacAddr& mac, const EtcPalMacAddr& c_mac) noexcept
+{
+  return mac.get() == c_mac;
+}
+
+inline bool operator!=(const MacAddr& mac, const EtcPalMacAddr& c_mac) noexcept
+{
+  return !(mac == c_mac);
 }
 
 // Standard operators
@@ -310,6 +587,66 @@ inline bool operator<=(const IpAddr& a, const IpAddr& b) noexcept
 }
 
 inline bool operator>=(const IpAddr& a, const IpAddr& b) noexcept
+{
+  return !(a < b);
+}
+
+inline bool operator==(const SockAddr& a, const SockAddr& b) noexcept
+{
+  return a.get() == b.get();
+}
+
+inline bool operator!=(const SockAddr& a, const SockAddr& b) noexcept
+{
+  return !(a == b);
+}
+
+inline bool operator<(const SockAddr& a, const SockAddr& b) noexcept
+{
+  return a.get() < b.get();
+}
+
+inline bool operator>(const SockAddr& a, const SockAddr& b) noexcept
+{
+  return b < a;
+}
+
+inline bool operator<=(const SockAddr& a, const SockAddr& b) noexcept
+{
+  return !(b < a);
+}
+
+inline bool operator>=(const SockAddr& a, const SockAddr& b) noexcept
+{
+  return !(a < b);
+}
+
+inline bool operator==(const MacAddr& a, const MacAddr& b) noexcept
+{
+  return a.get() == b.get();
+}
+
+inline bool operator!=(const MacAddr& a, const MacAddr& b) noexcept
+{
+  return !(a == b);
+}
+
+inline bool operator<(const MacAddr& a, const MacAddr& b) noexcept
+{
+  return a.get() < b.get();
+}
+
+inline bool operator>(const MacAddr& a, const MacAddr& b) noexcept
+{
+  return b < a;
+}
+
+inline bool operator<=(const MacAddr& a, const MacAddr& b) noexcept
+{
+  return !(b < a);
+}
+
+inline bool operator>=(const MacAddr& a, const MacAddr& b) noexcept
 {
   return !(a < b);
 }

--- a/include/etcpal/cpp/inet.h
+++ b/include/etcpal/cpp/inet.h
@@ -75,6 +75,8 @@ public:
   void SetAddress(uint32_t v4_data) noexcept;
   void SetAddress(const uint8_t* v6_data) noexcept;
   void SetAddress(const uint8_t* v6_data, unsigned long scope_id) noexcept;
+  void SetAddress(const std::array<uint8_t, ETCPAL_IPV6_BYTES>& v6_data) noexcept;
+  void SetAddress(const std::array<uint8_t, ETCPAL_IPV6_BYTES>& v6_data, unsigned long scope_id) noexcept;
 
   static IpAddr FromString(const std::string& ip_str) noexcept;
   static IpAddr WildcardV4() noexcept;
@@ -436,7 +438,6 @@ public:
   MacAddr(const EtcPalMacAddr& c_mac) noexcept;
   MacAddr& operator=(const EtcPalMacAddr& c_mac) noexcept;
   explicit MacAddr(const uint8_t* mac_data) noexcept;
-  explicit MacAddr(const std::array<uint8_t, ETCPAL_MAC_BYTES>& mac_data) noexcept;
 
   const EtcPalMacAddr& get() const noexcept;
   EtcPalMacAddr& get() noexcept;

--- a/include/etcpal/inet.h
+++ b/include/etcpal/inet.h
@@ -201,6 +201,29 @@ typedef struct EtcPalMacAddr
   uint8_t data[ETCPAL_MAC_BYTES];
 } EtcPalMacAddr;
 
+/*!
+ * \brief Compare two EtcPalMacAddrs numerically.
+ * \param[in] mac1ptr Pointer to first EtcPalMacAddr to compare.
+ * \param[in] mac2ptr Pointer to second EtcPalMacAddr to compare.
+ * \return < 0: mac1 < mac2
+ * \return 0: mac1 == mac2
+ * \return > 0: mac1 > mac2
+ */
+#define ETCPAL_MAC_CMP(mac1ptr, mac2ptr) memcmp((mac1ptr)->data, (mac2ptr)->data, ETCPAL_MAC_BYTES)
+
+/*! A null (all 0's) MAC address, used by ETCPAL_MAC_IS_NULL() for comparison. */
+extern const EtcPalMacAddr kEtcPalNullMacAddr;
+
+/*!
+ * \brief Determine if a MAC address is null.
+ *
+ * A MAC address is said to be 'null' when it is made up of all 0's.
+ *
+ * \param macptr Pointer to EtcPalMacAddr to null-check.
+ * \return true (MAC address is null) or false (MAC address is not null).
+ */
+#define ETCPAL_MAC_IS_NULL(macptr) (memcmp((macptr)->data, kEtcPalNullMacAddr.data, ETCPAL_MAC_BYTES) == 0)
+
 #define ETCPAL_NETINTINFO_NAME_LEN 64
 #define ETCPAL_NETINTINFO_FRIENDLY_NAME_LEN 64
 
@@ -247,7 +270,6 @@ void etcpal_ip_set_wildcard(etcpal_iptype_t type, EtcPalIpAddr* ip);
 
 int etcpal_ip_cmp(const EtcPalIpAddr* ip1, const EtcPalIpAddr* ip2);
 bool etcpal_ip_and_port_equal(const EtcPalSockAddr* sock1, const EtcPalSockAddr* sock2);
-int etcpal_mac_cmp(const EtcPalMacAddr* mac1, const EtcPalMacAddr* mac2);
 
 unsigned int etcpal_ip_mask_length(const EtcPalIpAddr* netmask);
 EtcPalIpAddr etcpal_ip_mask_from_length(etcpal_iptype_t type, unsigned int mask_length);
@@ -343,7 +365,7 @@ inline bool operator>=(const EtcPalSockAddr& a, const EtcPalSockAddr& b)
 
 inline bool operator==(const EtcPalMacAddr& a, const EtcPalMacAddr& b)
 {
-  return (etcpal_mac_cmp(&a, &b) == 0);
+  return (ETCPAL_MAC_CMP(&a, &b) == 0);
 }
 
 inline bool operator!=(const EtcPalMacAddr& a, const EtcPalMacAddr& b)
@@ -353,7 +375,7 @@ inline bool operator!=(const EtcPalMacAddr& a, const EtcPalMacAddr& b)
 
 inline bool operator<(const EtcPalMacAddr& a, const EtcPalMacAddr& b)
 {
-  return (etcpal_mac_cmp(&a, &b) < 0);
+  return (ETCPAL_MAC_CMP(&a, &b) < 0);
 }
 
 inline bool operator>(const EtcPalMacAddr& a, const EtcPalMacAddr& b)

--- a/include/etcpal/uuid.h
+++ b/include/etcpal/uuid.h
@@ -63,7 +63,7 @@ typedef struct EtcPalUuid
  */
 #define ETCPAL_UUID_CMP(uuid1ptr, uuid2ptr) memcmp((uuid1ptr)->data, (uuid2ptr)->data, ETCPAL_UUID_BYTES)
 
-/*! A null (all 0's) UUID, used by uuid_isnull() for comparison. */
+/*! A null (all 0's) UUID, used by ETCPAL_UUID_IS_NULL() for comparison. */
 extern const EtcPalUuid kEtcPalNullUuid;
 
 /*!

--- a/src/etcpal/inet.c
+++ b/src/etcpal/inet.c
@@ -21,6 +21,10 @@
 
 #include <stdio.h>
 
+/***************************** Global variables ******************************/
+
+const EtcPalMacAddr kEtcPalNullMacAddr = {{0}};
+
 /****************************** Private macros *******************************/
 
 #ifdef _MSC_VER
@@ -227,24 +231,6 @@ bool etcpal_ip_and_port_equal(const EtcPalSockAddr* sock1, const EtcPalSockAddr*
     return ((etcpal_ip_cmp(&sock1->ip, &sock2->ip) == 0) && sock1->port == sock2->port);
   else
     return false;
-}
-
-/*!
- * \brief Compare two EtcPalMacAddrs numerically.
- *
- * \param[in] mac1 First EtcPalMacAddr to compare.
- * \param[in] mac2 Second EtcPalMacAddr to compare.
- * \return < 0: mac1 < mac2
- * \return 0: mac1 == mac2
- * \return > 0: mac1 > mac2
- */
-int etcpal_mac_cmp(const EtcPalMacAddr* mac1, const EtcPalMacAddr* mac2)
-{
-  if (mac1 && mac2)
-  {
-    return memcmp(mac1->data, mac2->data, ETCPAL_MAC_BYTES);
-  }
-  return 0;
 }
 
 /*!

--- a/tests/unit/cpp/test_inet.cpp
+++ b/tests/unit/cpp/test_inet.cpp
@@ -165,7 +165,7 @@ TEST(etcpal_cpp_inet, ip_default_constructor_works)
   TEST_ASSERT_FALSE(ip.IsValid());
   TEST_ASSERT_FALSE(ip.IsV4());
   TEST_ASSERT_FALSE(ip.IsV6());
-  TEST_ASSERT_EQUAL(ip.type(), kEtcPalIpTypeInvalid);
+  TEST_ASSERT_TRUE(ip.type() == etcpal::IpAddrType::Invalid);
 }
 
 TEST(etcpal_cpp_inet, ip_copy_constructors_work)
@@ -208,7 +208,7 @@ TEST(etcpal_cpp_inet, ip_v4_addresses_assigned_properly)
   TEST_ASSERT_TRUE(ip.IsValid());
   TEST_ASSERT_TRUE(ip.IsV4());
   TEST_ASSERT_FALSE(ip.IsV6());
-  TEST_ASSERT_EQUAL(ip.type(), kEtcPalIpTypeV4);
+  TEST_ASSERT_TRUE(ip.type() == etcpal::IpAddrType::V4);
   TEST_ASSERT_EQUAL(ip.v4_data(), 0xdeadbeef);
 
   // Using the SetAddress() function
@@ -218,7 +218,7 @@ TEST(etcpal_cpp_inet, ip_v4_addresses_assigned_properly)
   TEST_ASSERT_TRUE(ip2.IsValid());
   TEST_ASSERT_TRUE(ip2.IsV4());
   TEST_ASSERT_FALSE(ip2.IsV6());
-  TEST_ASSERT_EQUAL(ip2.type(), kEtcPalIpTypeV4);
+  TEST_ASSERT_TRUE(ip2.type() == etcpal::IpAddrType::V4);
   TEST_ASSERT_EQUAL(ip2.v4_data(), 0xdeadbeef);
 }
 
@@ -233,7 +233,7 @@ TEST(etcpal_cpp_inet, ip_v6_addresses_assigned_properly)
   TEST_ASSERT_TRUE(ip.IsValid());
   TEST_ASSERT_TRUE(ip.IsV6());
   TEST_ASSERT_FALSE(ip.IsV4());
-  TEST_ASSERT_EQUAL(ip.type(), kEtcPalIpTypeV6);
+  TEST_ASSERT_TRUE(ip.type() == etcpal::IpAddrType::V6);
   TEST_ASSERT_EQUAL(0, std::memcmp(s_v6_data.data(), ip.v6_data(), ETCPAL_IPV6_BYTES));
   TEST_ASSERT_EQUAL(ip.scope_id(), 0);
 
@@ -243,7 +243,7 @@ TEST(etcpal_cpp_inet, ip_v6_addresses_assigned_properly)
   TEST_ASSERT_TRUE(ip2.IsValid());
   TEST_ASSERT_TRUE(ip2.IsV6());
   TEST_ASSERT_FALSE(ip2.IsV4());
-  TEST_ASSERT_EQUAL(ip2.type(), kEtcPalIpTypeV6);
+  TEST_ASSERT_TRUE(ip.type() == etcpal::IpAddrType::V6);
   TEST_ASSERT_EQUAL(0, std::memcmp(s_v6_data.data(), ip2.v6_data(), ETCPAL_IPV6_BYTES));
   TEST_ASSERT_EQUAL(ip2.scope_id(), 12);
 
@@ -254,7 +254,7 @@ TEST(etcpal_cpp_inet, ip_v6_addresses_assigned_properly)
   TEST_ASSERT_TRUE(ip3.IsValid());
   TEST_ASSERT_TRUE(ip3.IsV6());
   TEST_ASSERT_FALSE(ip3.IsV4());
-  TEST_ASSERT_EQUAL(ip3.type(), kEtcPalIpTypeV6);
+  TEST_ASSERT_TRUE(ip.type() == etcpal::IpAddrType::V6);
   TEST_ASSERT_EQUAL(0, std::memcmp(s_v6_data.data(), ip3.v6_data(), ETCPAL_IPV6_BYTES));
   TEST_ASSERT_EQUAL(ip3.scope_id(), 0);
 
@@ -264,7 +264,7 @@ TEST(etcpal_cpp_inet, ip_v6_addresses_assigned_properly)
   TEST_ASSERT_TRUE(ip4.IsValid());
   TEST_ASSERT_TRUE(ip4.IsV6());
   TEST_ASSERT_FALSE(ip4.IsV4());
-  TEST_ASSERT_EQUAL(ip4.type(), kEtcPalIpTypeV6);
+  TEST_ASSERT_TRUE(ip.type() == etcpal::IpAddrType::V6);
   TEST_ASSERT_EQUAL(0, std::memcmp(s_v6_data.data(), ip4.v6_data(), ETCPAL_IPV6_BYTES));
   TEST_ASSERT_EQUAL(ip4.scope_id(), 12);
 }
@@ -326,9 +326,9 @@ TEST(etcpal_cpp_inet, ip_is_wildcard_works)
   TEST_ASSERT_TRUE(wildcard.IsWildcard());
   wildcard = etcpal::IpAddr::WildcardV6();
   TEST_ASSERT_TRUE(wildcard.IsWildcard());
-  wildcard = etcpal::IpAddr::Wildcard(kEtcPalIpTypeV4);
+  wildcard = etcpal::IpAddr::Wildcard(etcpal::IpAddrType::V4);
   TEST_ASSERT_TRUE(wildcard.IsWildcard());
-  wildcard = etcpal::IpAddr::Wildcard(kEtcPalIpTypeV6);
+  wildcard = etcpal::IpAddr::Wildcard(etcpal::IpAddrType::V6);
   TEST_ASSERT_TRUE(wildcard.IsWildcard());
 }
 

--- a/tests/unit/live/test_inet.c
+++ b/tests/unit/live/test_inet.c
@@ -372,6 +372,29 @@ TEST(etcpal_inet, inet_string_functions_work)
               (0 == strcmp(str, "FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF")));
 }
 
+TEST(etcpal_inet, mac_is_null_works)
+{
+  EtcPalMacAddr mac = {{0}};
+  TEST_ASSERT_TRUE(ETCPAL_MAC_IS_NULL(&mac));
+
+  mac = kEtcPalNullMacAddr;
+  TEST_ASSERT_TRUE(ETCPAL_MAC_IS_NULL(&mac));
+
+  for (uint8_t i = 0; i < ETCPAL_MAC_BYTES; ++i)
+    mac.data[i] = i;
+  TEST_ASSERT_FALSE(ETCPAL_MAC_IS_NULL(&mac));
+}
+
+TEST(etcpal_inet, mac_compare_works)
+{
+  const EtcPalMacAddr mac1 = {{1, 2, 3, 4, 5, 6}};
+  const EtcPalMacAddr mac2 = {{1, 2, 3, 4, 5, 7}};
+
+  TEST_ASSERT_EQUAL(0, ETCPAL_MAC_CMP(&mac1, &mac1));
+  TEST_ASSERT_GREATER_THAN(0, ETCPAL_MAC_CMP(&mac2, &mac1));
+  TEST_ASSERT_LESS_THAN(0, ETCPAL_MAC_CMP(&mac1, &mac2));
+}
+
 TEST(etcpal_inet, mac_to_string_conversion_works)
 {
   const EtcPalMacAddr mac = {{1, 2, 3, 4, 5, 6}};
@@ -401,7 +424,7 @@ TEST(etcpal_inet, string_to_mac_conversion_works)
     char msg_buf[100];
     sprintf(msg_buf, "Failed on input: %s", good_strings[i]);
     TEST_ASSERT_EQUAL_MESSAGE(etcpal_string_to_mac(good_strings[i], &mac), kEtcPalErrOk, msg_buf);
-    TEST_ASSERT_EQUAL_INT_MESSAGE(0, etcpal_mac_cmp(&mac, &good_str_mac), msg_buf);
+    TEST_ASSERT_EQUAL_INT_MESSAGE(0, ETCPAL_MAC_CMP(&mac, &good_str_mac), msg_buf);
   }
 
   for (size_t i = 0; i < (sizeof(bad_strings) / sizeof(const char*)); ++i)
@@ -423,6 +446,8 @@ TEST_GROUP_RUNNER(etcpal_inet)
   RUN_TEST_CASE(etcpal_inet, ip_mask_length_works);
   RUN_TEST_CASE(etcpal_inet, ip_mask_from_length_works);
   RUN_TEST_CASE(etcpal_inet, inet_string_functions_work);
+  RUN_TEST_CASE(etcpal_inet, mac_is_null_works);
+  RUN_TEST_CASE(etcpal_inet, mac_compare_works);
   RUN_TEST_CASE(etcpal_inet, mac_to_string_conversion_works);
   RUN_TEST_CASE(etcpal_inet, string_to_mac_conversion_works);
 }

--- a/tests/unit/live/test_inet.c
+++ b/tests/unit/live/test_inet.c
@@ -41,7 +41,7 @@ TEST_TEAR_DOWN(etcpal_inet)
 TEST(etcpal_inet, invalid_calls_fail)
 {
   // TODO fill this out with the rest of the functions
-  char* mac_str_buf = (char*)0xdeadbeef;
+  char mac_str_buf[ETCPAL_MAC_STRING_BYTES];
   const EtcPalMacAddr mac = {0};
   TEST_ASSERT_NOT_EQUAL(kEtcPalErrOk, etcpal_mac_to_string(NULL, mac_str_buf, ETCPAL_MAC_STRING_BYTES));
   TEST_ASSERT_NOT_EQUAL(kEtcPalErrOk, etcpal_mac_to_string(&mac, NULL, ETCPAL_MAC_STRING_BYTES));


### PR DESCRIPTION
I added these after getting frustrated with writing MAC address to/from string conversions in the Broker in multiple places.