### PR TITLE
Modify IP address to/from string functions for mnemonic consistency

### DIFF
--- a/examples/netint/netint_example.c
+++ b/examples/netint/netint_example.c
@@ -48,11 +48,11 @@ void create_format_strings(const EtcPalNetintInfo* netint_arr, size_t num_interf
 
   for (const EtcPalNetintInfo* netint = netint_arr; netint < netint_arr + num_interfaces; ++netint)
   {
-    char addr_str[ETCPAL_INET6_ADDRSTRLEN] = {'\0'};
-    char netmask_str[ETCPAL_INET6_ADDRSTRLEN] = {'\0'};
+    char addr_str[ETCPAL_IP_STRING_BYTES] = {'\0'};
+    char netmask_str[ETCPAL_IP_STRING_BYTES] = {'\0'};
 
-    etcpal_inet_ntop(&netint->addr, addr_str, ETCPAL_INET6_ADDRSTRLEN);
-    etcpal_inet_ntop(&netint->mask, netmask_str, ETCPAL_INET6_ADDRSTRLEN);
+    etcpal_ip_to_string(&netint->addr, addr_str);
+    etcpal_ip_to_string(&netint->mask, netmask_str);
 
     size_t id_len = strlen(netint->id);
     size_t addr_len = strlen(addr_str);
@@ -106,12 +106,12 @@ int main(void)
 
   for (const EtcPalNetintInfo* netint = netint_arr; netint < netint_arr + num_interfaces; ++netint)
   {
-    char addr_str[ETCPAL_INET6_ADDRSTRLEN] = {'\0'};
-    char netmask_str[ETCPAL_INET6_ADDRSTRLEN] = {'\0'};
+    char addr_str[ETCPAL_IP_STRING_BYTES] = {'\0'};
+    char netmask_str[ETCPAL_IP_STRING_BYTES] = {'\0'};
     char mac_str[ETCPAL_MAC_STRING_BYTES];
-    etcpal_inet_ntop(&netint->addr, addr_str, ETCPAL_INET6_ADDRSTRLEN);
-    etcpal_inet_ntop(&netint->mask, netmask_str, ETCPAL_INET6_ADDRSTRLEN);
-    etcpal_mac_to_string(&netint->mac, mac_str, ETCPAL_MAC_STRING_BYTES);
+    etcpal_ip_to_string(&netint->addr, addr_str);
+    etcpal_ip_to_string(&netint->mask, netmask_str);
+    etcpal_mac_to_string(&netint->mac, mac_str);
     printf(line_format, netint->id, addr_str, netmask_str, mac_str, netint->index);
   }
 

--- a/include/etcpal/cpp/inet.h
+++ b/include/etcpal/cpp/inet.h
@@ -158,11 +158,11 @@ ETCPAL_CONSTEXPR_14_OR_INLINE EtcPalIpAddr& IpAddr::get() noexcept
 
 /// \brief Convert the IP address to a string representation.
 ///
-/// See etcpal_inet_ntop() for more information.
+/// See etcpal_ip_to_string() for more information.
 inline std::string IpAddr::ToString() const
 {
-  char str_buf[ETCPAL_INET6_ADDRSTRLEN];
-  auto result = etcpal_inet_ntop(&addr_, str_buf, ETCPAL_INET6_ADDRSTRLEN);
+  char str_buf[ETCPAL_IP_STRING_BYTES];
+  auto result = etcpal_ip_to_string(&addr_, str_buf);
   if (result == kEtcPalErrOk)
     return str_buf;
   else
@@ -305,20 +305,20 @@ inline void IpAddr::SetAddress(const uint8_t* v6_data, unsigned long scope_id) n
 
 /// \brief Construct an IpAddr from a string representation.
 ///
-/// See etcpal_inet_pton() for more information.
+/// See etcpal_string_to_ip() for more information.
 inline IpAddr IpAddr::FromString(const char* ip_str) noexcept
 {
   IpAddr result;
-  if (etcpal_inet_pton(kEtcPalIpTypeV4, ip_str, &result.addr_) != kEtcPalErrOk)
+  if (etcpal_string_to_ip(kEtcPalIpTypeV4, ip_str, &result.addr_) != kEtcPalErrOk)
   {
-    etcpal_inet_pton(kEtcPalIpTypeV6, ip_str, &result.addr_);
+    etcpal_string_to_ip(kEtcPalIpTypeV6, ip_str, &result.addr_);
   }
   return result;
 }
 
 /// \brief Construct an IpAddr from a string representation.
 ///
-/// See etcpal_inet_pton() for more information.
+/// See etcpal_string_to_ip() for more information.
 inline IpAddr IpAddr::FromString(const std::string& ip_str) noexcept
 {
   return FromString(ip_str.c_str());
@@ -727,7 +727,7 @@ ETCPAL_CONSTEXPR_14_OR_INLINE EtcPalMacAddr& MacAddr::get() noexcept
 inline std::string MacAddr::ToString() const
 {
   char str_buf[ETCPAL_MAC_STRING_BYTES];
-  etcpal_mac_to_string(&addr_, str_buf, ETCPAL_MAC_STRING_BYTES);
+  etcpal_mac_to_string(&addr_, str_buf);
   return str_buf;
 }
 

--- a/include/etcpal/inet.h
+++ b/include/etcpal/inet.h
@@ -381,10 +381,8 @@ typedef struct EtcPalNetintInfo
   bool is_default;
 } EtcPalNetintInfo;
 
-/*! Maximum length of the string representation of an IPv4 address. */
-#define ETCPAL_INET_ADDRSTRLEN 16
-/*! Maximum length of the string representation of an IPv6 address. */
-#define ETCPAL_INET6_ADDRSTRLEN 46
+/*! Maximum length of the string representation of an IP address. */
+#define ETCPAL_IP_STRING_BYTES 46
 /*! Maximum length of the string representation of a MAC address. */
 #define ETCPAL_MAC_STRING_BYTES 18
 
@@ -407,9 +405,9 @@ size_t ip_etcpal_to_os(const EtcPalIpAddr* ip, etcpal_os_ipaddr_t* os_ip);
 bool sockaddr_os_to_etcpal(const etcpal_os_sockaddr_t* os_sa, EtcPalSockAddr* sa);
 size_t sockaddr_etcpal_to_os(const EtcPalSockAddr* sa, etcpal_os_sockaddr_t* os_sa);
 
-etcpal_error_t etcpal_inet_ntop(const EtcPalIpAddr* src, char* dest, size_t size);
-etcpal_error_t etcpal_inet_pton(etcpal_iptype_t type, const char* src, EtcPalIpAddr* dest);
-etcpal_error_t etcpal_mac_to_string(const EtcPalMacAddr* src, char* dest, size_t size);
+etcpal_error_t etcpal_ip_to_string(const EtcPalIpAddr* src, char* dest);
+etcpal_error_t etcpal_string_to_ip(etcpal_iptype_t type, const char* src, EtcPalIpAddr* dest);
+etcpal_error_t etcpal_mac_to_string(const EtcPalMacAddr* src, char* dest);
 etcpal_error_t etcpal_string_to_mac(const char* src, EtcPalMacAddr* dest);
 
 #ifdef __cplusplus

--- a/include/etcpal/netint.h
+++ b/include/etcpal/netint.h
@@ -68,7 +68,7 @@
  *
  * \code
  * EtcPalIpAddr dest;
- * etcpal_inet_pton(kEtcPalIpTypeV4, "192.168.200.35", &dest);
+ * etcpal_string_to_ip(kEtcPalIpTypeV4, "192.168.200.35", &dest);
  *
  * unsigned int index;
  * etcpal_netint_get_interface_for_dest(&dest, &index); // Index now holds the interface that will be used

--- a/include/etcpal_mock/socket.h
+++ b/include/etcpal_mock/socket.h
@@ -26,8 +26,8 @@
 #include "fff.h"
 
 // We don't mock:
-// etcpal_inet_pton()
-// etcpal_inet_ntop()
+// etcpal_ip_to_string()
+// etcpal_string_to_ip()
 // sockaddr_os_to_etcpal()
 // sockaddr_etcpal_to_os()
 

--- a/src/etcpal/inet.c
+++ b/src/etcpal/inet.c
@@ -456,16 +456,14 @@ bool etcpal_ip_network_portions_equal(const EtcPalIpAddr* ip1, const EtcPalIpAdd
  */
 
 /*!
- * \fn etcpal_error_t etcpal_inet_ntop(const EtcPalIpAddr* src, char* dest, size_t size)
+ * \fn etcpal_error_t etcpal_ip_to_string(const EtcPalIpAddr* src, char* dest)
  * \brief Convert IPv4 and IPv6 addresses from binary to text form.
  *
- * Refer to your favorite inet_ntop() man page for more information.
- *
- * Differences from POSIX: af parameter is omitted because that information is contained in the
- * EtcPalIpAddr.
+ * This function uses each platform's inet_ntop() function under the hood.
  *
  * \param[in] src Address to convert to string form.
- * \param[out] dest Filled in on success with the string-represented address.
+ * \param[out] dest Filled in on success with the string-represented address. To avoid undefined
+ *                  behavior, this buffer must be at least of size #ETCPAL_IP_STRING_BYTES.
  * \param[in] size Size in bytes of dest buf.
  * \return #kEtcPalErrOk: Success.
  * \return #kEtcPalErrInvalid: Invalid parameter.
@@ -474,13 +472,10 @@ bool etcpal_ip_network_portions_equal(const EtcPalIpAddr* ip1, const EtcPalIpAdd
 
 /* This documentation appears here; the actual functions are in os/[os name]/etcpal/os_inet.c */
 /*!
- * \fn etcpal_error_t etcpal_inet_pton(etcpal_iptype_t type, const char* src, EtcPalIpAddr* dest)
+ * \fn etcpal_error_t etcpal_string_to_ip(etcpal_iptype_t type, const char* src, EtcPalIpAddr* dest)
  * \brief Convert IPv4 and IPv6 addresses from text to binary form.
  *
- * Refer to your favorite inet_pton() man page for more information.
- *
- * Differences from POSIX: etcpal_iptype_t used instead of AF_* value, since this function is only
- * used for IP addresses.
+ * This function uses each platform's inet_pton() function under the hood.
  *
  * \param[in] type Type of string-represented IP address pointed to by src.
  * \param[in] src Character string containing a string-represented IP address.
@@ -499,13 +494,12 @@ bool etcpal_ip_network_portions_equal(const EtcPalIpAddr* ip1, const EtcPalIpAdd
  * \param[in] src MAC address to convert to a string.
  * \param[out] dest Character buffer to which to write the resulting string. Must be at least of
  *                  size #ETCPAL_MAC_STRING_BYTES.
- * \param[in] size Size of destination buffer.
  * \return #kEtcPalErrOk: Conversion successful.
  * \return #kEtcPalErrInvalid: Invalid argument.
  */
-etcpal_error_t etcpal_mac_to_string(const EtcPalMacAddr* src, char* dest, size_t size)
+etcpal_error_t etcpal_mac_to_string(const EtcPalMacAddr* src, char* dest)
 {
-  if (!src || !dest || size < ETCPAL_MAC_STRING_BYTES)
+  if (!src || !dest)
     return kEtcPalErrInvalid;
 
   ETCPAL_SPRINTF(dest, "%02x:%02x:%02x:%02x:%02x:%02x", src->data[0], src->data[1], src->data[2], src->data[3],

--- a/src/etcpal/inet.c
+++ b/src/etcpal/inet.c
@@ -464,7 +464,6 @@ bool etcpal_ip_network_portions_equal(const EtcPalIpAddr* ip1, const EtcPalIpAdd
  * \param[in] src Address to convert to string form.
  * \param[out] dest Filled in on success with the string-represented address. To avoid undefined
  *                  behavior, this buffer must be at least of size #ETCPAL_IP_STRING_BYTES.
- * \param[in] size Size in bytes of dest buf.
  * \return #kEtcPalErrOk: Success.
  * \return #kEtcPalErrInvalid: Invalid parameter.
  * \return #kEtcPalErrSys: System call failed.

--- a/src/etcpal/socket.dox
+++ b/src/etcpal/socket.dox
@@ -418,8 +418,8 @@ etcpal_error_t etcpal_poll_wait(EtcPalPollContext *context, EtcPalPollEvent *eve
  * {
  *   do
  *   {
- *     char inet_str[ETCPAL_INET6_ADDRSTRLEN];
- *     if (kEtcPalErrOk == etcpal_inet_ntop(&info.ai_addr.ip, inet_str, ETCPAL_INET6_ADDRSTRLEN))
+ *     char inet_str[ETCPAL_IP_STRING_BYTES];
+ *     if (kEtcPalErrOk == etcpal_ip_to_string(&info.ai_addr.ip, inet_str))
  *     {
  *       printf("Address: %s\n", inet_str);
  *     }

--- a/src/etcpal/uuid.c
+++ b/src/etcpal/uuid.c
@@ -54,7 +54,7 @@ const EtcPalUuid kEtcPalNullUuid = {{0}};
  *
  * \param[in] uuid UUID to convert to a string.
  * \param[out] buf Character buffer to which to write the resulting string. To avoid undefined
- *                 behavior, this buffer should be at least of size #ETCPAL_UUID_STRING_BYTES.
+ *                 behavior, this buffer must be at least of size #ETCPAL_UUID_STRING_BYTES.
  * \return true (conversion successful) or false (invalid argument).
  */
 bool etcpal_uuid_to_string(const EtcPalUuid* uuid, char* buf)

--- a/src/os/linux/etcpal/os_inet.c
+++ b/src/os/linux/etcpal/os_inet.c
@@ -91,7 +91,7 @@ size_t sockaddr_etcpal_to_os(const EtcPalSockAddr* sa, etcpal_os_sockaddr_t* os_
   return ret;
 }
 
-etcpal_error_t etcpal_inet_ntop(const EtcPalIpAddr* src, char* dest, size_t size)
+etcpal_error_t etcpal_ip_to_string(const EtcPalIpAddr* src, char* dest)
 {
   if (!src || !dest)
     return kEtcPalErrInvalid;
@@ -101,14 +101,14 @@ etcpal_error_t etcpal_inet_ntop(const EtcPalIpAddr* src, char* dest, size_t size
     case kEtcPalIpTypeV4: {
       struct in_addr addr;
       addr.s_addr = htonl(ETCPAL_IP_V4_ADDRESS(src));
-      if (NULL != inet_ntop(AF_INET, &addr, dest, (socklen_t)size))
+      if (NULL != inet_ntop(AF_INET, &addr, dest, ETCPAL_IP_STRING_BYTES))
         return kEtcPalErrOk;
       return kEtcPalErrInvalid;
     }
     case kEtcPalIpTypeV6: {
       struct in6_addr addr;
       memcpy(addr.s6_addr, ETCPAL_IP_V6_ADDRESS(src), ETCPAL_IPV6_BYTES);
-      if (NULL != inet_ntop(AF_INET6, &addr, dest, (socklen_t)size))
+      if (NULL != inet_ntop(AF_INET6, &addr, dest, ETCPAL_IP_STRING_BYTES))
         return kEtcPalErrOk;
       return kEtcPalErrInvalid;
     }
@@ -117,7 +117,7 @@ etcpal_error_t etcpal_inet_ntop(const EtcPalIpAddr* src, char* dest, size_t size
   }
 }
 
-etcpal_error_t etcpal_inet_pton(etcpal_iptype_t type, const char* src, EtcPalIpAddr* dest)
+etcpal_error_t etcpal_string_to_ip(etcpal_iptype_t type, const char* src, EtcPalIpAddr* dest)
 {
   if (!src || !dest)
     return kEtcPalErrInvalid;

--- a/src/os/linux/etcpal/os_netint.c
+++ b/src/os/linux/etcpal/os_netint.c
@@ -567,22 +567,22 @@ void debug_print_routing_table(RoutingTable* table)
   printf("%-40s %-40s %-40s %-10s %s\n", "Address", "Mask", "Gateway", "Metric", "Index");
   for (RoutingTableEntry* entry = table->entries; entry < table->entries + table->size; ++entry)
   {
-    char addr_str[ETCPAL_INET6_ADDRSTRLEN];
-    char mask_str[ETCPAL_INET6_ADDRSTRLEN];
-    char gw_str[ETCPAL_INET6_ADDRSTRLEN];
+    char addr_str[ETCPAL_IP_STRING_BYTES];
+    char mask_str[ETCPAL_IP_STRING_BYTES];
+    char gw_str[ETCPAL_IP_STRING_BYTES];
 
     if (!ETCPAL_IP_IS_INVALID(&entry->addr))
-      etcpal_inet_ntop(&entry->addr, addr_str, ETCPAL_INET6_ADDRSTRLEN);
+      etcpal_ip_to_string(&entry->addr, addr_str);
     else
       strcpy(addr_str, "0.0.0.0");
 
     if (!ETCPAL_IP_IS_INVALID(&entry->mask))
-      etcpal_inet_ntop(&entry->mask, mask_str, ETCPAL_INET6_ADDRSTRLEN);
+      etcpal_ip_to_string(&entry->mask, mask_str);
     else
       strcpy(mask_str, "0.0.0.0");
 
     if (!ETCPAL_IP_IS_INVALID(&entry->gateway))
-      etcpal_inet_ntop(&entry->gateway, gw_str, ETCPAL_INET6_ADDRSTRLEN);
+      etcpal_ip_to_string(&entry->gateway, gw_str);
     else
       strcpy(gw_str, "0.0.0.0");
 

--- a/src/os/lwip/etcpal/os_inet.c
+++ b/src/os/lwip/etcpal/os_inet.c
@@ -113,7 +113,7 @@ size_t sockaddr_etcpal_to_os(const EtcPalSockAddr* sa, etcpal_os_sockaddr_t* os_
   return ret;
 }
 
-etcpal_error_t etcpal_inet_ntop(const EtcPalIpAddr* src, char* dest, size_t size)
+etcpal_error_t etcpal_ip_to_string(const EtcPalIpAddr* src, char* dest)
 {
   if (!src || !dest)
     return kEtcPalErrInvalid;
@@ -123,14 +123,14 @@ etcpal_error_t etcpal_inet_ntop(const EtcPalIpAddr* src, char* dest, size_t size
     case kEtcPalIpTypeV4: {
       struct in_addr addr;
       addr.s_addr = lwip_htonl(ETCPAL_IP_V4_ADDRESS(src));
-      if (NULL != lwip_inet_ntop(AF_INET, &addr, dest, size))
+      if (NULL != lwip_inet_ntop(AF_INET, &addr, dest, ETCPAL_IP_STRING_BYTES))
         return kEtcPalErrOk;
       return errno_lwip_to_etcpal(errno);
     }
     case kEtcPalIpTypeV6: {
       struct in6_addr addr;
       memcpy(addr.s6_addr, ETCPAL_IP_V6_ADDRESS(src), ETCPAL_IPV6_BYTES);
-      if (NULL != lwip_inet_ntop(AF_INET6, &addr, dest, size))
+      if (NULL != lwip_inet_ntop(AF_INET6, &addr, dest, ETCPAL_IP_STRING_BYTES))
         return kEtcPalErrOk;
       return errno_lwip_to_etcpal(errno);
     }
@@ -139,7 +139,7 @@ etcpal_error_t etcpal_inet_ntop(const EtcPalIpAddr* src, char* dest, size_t size
   }
 }
 
-etcpal_error_t etcpal_inet_pton(etcpal_iptype_t type, const char* src, EtcPalIpAddr* dest)
+etcpal_error_t etcpal_string_to_ip(etcpal_iptype_t type, const char* src, EtcPalIpAddr* dest)
 {
   if (!src || !dest)
     return kEtcPalErrInvalid;

--- a/src/os/macos/etcpal/os_inet.c
+++ b/src/os/macos/etcpal/os_inet.c
@@ -91,7 +91,7 @@ size_t sockaddr_etcpal_to_os(const EtcPalSockAddr* sa, etcpal_os_sockaddr_t* os_
   return ret;
 }
 
-etcpal_error_t etcpal_inet_ntop(const EtcPalIpAddr* src, char* dest, size_t size)
+etcpal_error_t etcpal_ip_to_string(const EtcPalIpAddr* src, char* dest)
 {
   if (!src || !dest)
     return kEtcPalErrInvalid;
@@ -101,14 +101,14 @@ etcpal_error_t etcpal_inet_ntop(const EtcPalIpAddr* src, char* dest, size_t size
     case kEtcPalIpTypeV4: {
       struct in_addr addr;
       addr.s_addr = htonl(ETCPAL_IP_V4_ADDRESS(src));
-      if (NULL != inet_ntop(AF_INET, &addr, dest, (socklen_t)size))
+      if (NULL != inet_ntop(AF_INET, &addr, dest, ETCPAL_IP_STRING_BYTES))
         return kEtcPalErrOk;
       return kEtcPalErrInvalid;
     }
     case kEtcPalIpTypeV6: {
       struct in6_addr addr;
       memcpy(addr.s6_addr, ETCPAL_IP_V6_ADDRESS(src), ETCPAL_IPV6_BYTES);
-      if (NULL != inet_ntop(AF_INET6, &addr, dest, (socklen_t)size))
+      if (NULL != inet_ntop(AF_INET6, &addr, dest, ETCPAL_IP_STRING_BYTES))
         return kEtcPalErrOk;
       return kEtcPalErrInvalid;
     }
@@ -117,7 +117,7 @@ etcpal_error_t etcpal_inet_ntop(const EtcPalIpAddr* src, char* dest, size_t size
   }
 }
 
-etcpal_error_t etcpal_inet_pton(etcpal_iptype_t type, const char* src, EtcPalIpAddr* dest)
+etcpal_error_t etcpal_string_to_ip(etcpal_iptype_t type, const char* src, EtcPalIpAddr* dest)
 {
   if (!src || !dest)
     return kEtcPalErrInvalid;

--- a/src/os/macos/etcpal/os_netint.c
+++ b/src/os/macos/etcpal/os_netint.c
@@ -694,23 +694,23 @@ void debug_print_routing_table(RoutingTable* table)
 
   for (RoutingTableEntry* entry = table->entries; entry < table->entries + table->size; ++entry)
   {
-    char addr_str[ETCPAL_INET6_ADDRSTRLEN];
-    char mask_str[ETCPAL_INET6_ADDRSTRLEN];
-    char gw_str[ETCPAL_INET6_ADDRSTRLEN];
+    char addr_str[ETCPAL_IP_STRING_BYTES];
+    char mask_str[ETCPAL_IP_STRING_BYTES];
+    char gw_str[ETCPAL_IP_STRING_BYTES];
     char ifname_str[IF_NAMESIZE];
 
     if (!ETCPAL_IP_IS_INVALID(&entry->addr))
-      etcpal_inet_ntop(&entry->addr, addr_str, ETCPAL_INET6_ADDRSTRLEN);
+      etcpal_ip_to_string(&entry->addr, addr_str);
     else
       strcpy(addr_str, "0.0.0.0");
 
     if (!ETCPAL_IP_IS_INVALID(&entry->mask))
-      etcpal_inet_ntop(&entry->mask, mask_str, ETCPAL_INET6_ADDRSTRLEN);
+      etcpal_ip_to_string(&entry->mask, mask_str);
     else
       strcpy(mask_str, "0.0.0.0");
 
     if (!ETCPAL_IP_IS_INVALID(&entry->gateway))
-      etcpal_inet_ntop(&entry->gateway, gw_str, ETCPAL_INET6_ADDRSTRLEN);
+      etcpal_ip_to_string(&entry->gateway, gw_str);
     else
       strcpy(gw_str, "");
 
@@ -721,8 +721,8 @@ void debug_print_routing_table(RoutingTable* table)
 
   if (table->default_route)
   {
-    char gw_str[ETCPAL_INET6_ADDRSTRLEN];
-    etcpal_inet_ntop(&table->default_route->gateway, gw_str, ETCPAL_INET6_ADDRSTRLEN);
+    char gw_str[ETCPAL_IP_STRING_BYTES];
+    etcpal_ip_to_string(&table->default_route->gateway, gw_str);
     printf("Default route: %s (%u)\n", gw_str, table->default_route->interface_index);
   }
   else

--- a/src/os/mqx/etcpal/os_inet.c
+++ b/src/os/mqx/etcpal/os_inet.c
@@ -109,7 +109,7 @@ size_t sockaddr_etcpal_to_os(const EtcPalSockAddr* sa, struct sockaddr* os_sa)
   return ret;
 }
 
-etcpal_error_t etcpal_inet_ntop(const EtcPalIpAddr* src, char* dest, size_t size)
+etcpal_error_t etcpal_ip_to_string(const EtcPalIpAddr* src, char* dest)
 {
   if (!src || !dest)
     return kEtcPalErrInvalid;
@@ -120,14 +120,14 @@ etcpal_error_t etcpal_inet_ntop(const EtcPalIpAddr* src, char* dest, size_t size
       struct in_addr addr;
       /* RTCS expects host byte order in their in_addrs. Thus no htonl is needed. */
       addr.s_addr = ETCPAL_IP_V4_ADDRESS(src);
-      if (NULL != inet_ntop(AF_INET, &addr, dest, size))
+      if (NULL != inet_ntop(AF_INET, &addr, dest, ETCPAL_IP_STRING_BYTES))
         return kEtcPalErrOk;
       return kEtcPalErrSys;
     }
     case kEtcPalIpTypeV6: {
       struct in6_addr addr;
       memcpy(addr.s6_addr, ETCPAL_IP_V6_ADDRESS(src), ETCPAL_IPV6_BYTES);
-      if (NULL != inet_ntop(AF_INET6, &addr, dest, size))
+      if (NULL != inet_ntop(AF_INET6, &addr, dest, ETCPAL_IP_STRING_BYTES))
         return kEtcPalErrOk;
       return kEtcPalErrSys;
     }
@@ -136,7 +136,7 @@ etcpal_error_t etcpal_inet_ntop(const EtcPalIpAddr* src, char* dest, size_t size
   }
 }
 
-etcpal_error_t etcpal_inet_pton(etcpal_iptype_t type, const char* src, EtcPalIpAddr* dest)
+etcpal_error_t etcpal_string_to_ip(etcpal_iptype_t type, const char* src, EtcPalIpAddr* dest)
 {
   if (!src || !dest)
     return kEtcPalErrInvalid;

--- a/src/os/windows/etcpal/os_inet.c
+++ b/src/os/windows/etcpal/os_inet.c
@@ -92,7 +92,7 @@ size_t sockaddr_etcpal_to_os(const EtcPalSockAddr* sa, etcpal_os_sockaddr_t* os_
   return ret;
 }
 
-etcpal_error_t etcpal_inet_ntop(const EtcPalIpAddr* src, char* dest, size_t size)
+etcpal_error_t etcpal_ip_to_string(const EtcPalIpAddr* src, char* dest)
 {
   if (!src || !dest)
     return kEtcPalErrInvalid;
@@ -102,14 +102,14 @@ etcpal_error_t etcpal_inet_ntop(const EtcPalIpAddr* src, char* dest, size_t size
     case kEtcPalIpTypeV4: {
       struct in_addr addr;
       addr.s_addr = htonl(ETCPAL_IP_V4_ADDRESS(src));
-      if (NULL != inet_ntop(AF_INET, &addr, dest, size))
+      if (NULL != inet_ntop(AF_INET, &addr, dest, ETCPAL_IP_STRING_BYTES))
         return kEtcPalErrOk;
       return err_winsock_to_etcpal(WSAGetLastError());
     }
     case kEtcPalIpTypeV6: {
       struct in6_addr addr;
       memcpy(addr.s6_addr, ETCPAL_IP_V6_ADDRESS(src), ETCPAL_IPV6_BYTES);
-      if (NULL != inet_ntop(AF_INET6, &addr, dest, size))
+      if (NULL != inet_ntop(AF_INET6, &addr, dest, ETCPAL_IP_STRING_BYTES))
         return kEtcPalErrOk;
       return err_winsock_to_etcpal(WSAGetLastError());
     }
@@ -118,7 +118,7 @@ etcpal_error_t etcpal_inet_ntop(const EtcPalIpAddr* src, char* dest, size_t size
   }
 }
 
-etcpal_error_t etcpal_inet_pton(etcpal_iptype_t type, const char* src, EtcPalIpAddr* dest)
+etcpal_error_t etcpal_string_to_ip(etcpal_iptype_t type, const char* src, EtcPalIpAddr* dest)
 {
   if (!src || !dest)
     return kEtcPalErrInvalid;

--- a/tests/unit/live/test_inet.c
+++ b/tests/unit/live/test_inet.c
@@ -53,9 +53,8 @@ TEST(etcpal_inet, invalid_calls_fail)
   // TODO fill this out with the rest of the functions
   char mac_str_buf[ETCPAL_MAC_STRING_BYTES];
   const EtcPalMacAddr mac = {0};
-  TEST_ASSERT_NOT_EQUAL(kEtcPalErrOk, etcpal_mac_to_string(NULL, mac_str_buf, ETCPAL_MAC_STRING_BYTES));
-  TEST_ASSERT_NOT_EQUAL(kEtcPalErrOk, etcpal_mac_to_string(&mac, NULL, ETCPAL_MAC_STRING_BYTES));
-  TEST_ASSERT_NOT_EQUAL(kEtcPalErrOk, etcpal_mac_to_string(&mac, mac_str_buf, ETCPAL_MAC_STRING_BYTES - 1));
+  TEST_ASSERT_NOT_EQUAL(kEtcPalErrOk, etcpal_mac_to_string(NULL, mac_str_buf));
+  TEST_ASSERT_NOT_EQUAL(kEtcPalErrOk, etcpal_mac_to_string(&mac, NULL));
 }
 
 TEST(etcpal_inet, ipaddr_init_macros_work)
@@ -350,8 +349,8 @@ TEST(etcpal_inet, ip_mask_from_length_works)
   TEST_ASSERT_EQUAL_UINT8_ARRAY(ETCPAL_IP_V6_ADDRESS(&mask_out), v6_compare_val, ETCPAL_IPV6_BYTES);
 }
 
-// For inet_xtox
-char str[ETCPAL_INET6_ADDRSTRLEN];
+// For ip/string functions
+char str[ETCPAL_IP_STRING_BYTES];
 const char* test_ip4_1 = "0.0.0.0";
 const char* test_ip4_2 = "255.255.255.255";
 const char* test_ip4_fail = "256.256.256.256";
@@ -364,41 +363,44 @@ const uint8_t test_ip6_3_bin[ETCPAL_IPV6_BYTES] = {0xff, 0xff, 0xff, 0xff, 0xff,
                                                    0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff};
 const char* test_ip6_fail = "abcd::ef01::2345";
 
-TEST(etcpal_inet, inet_string_functions_work)
+TEST(etcpal_inet, ip_to_string_conversion_works)
 {
   EtcPalIpAddr addr;
 
-  // Test etcpal_inet_pton()
-  TEST_ASSERT_EQUAL(kEtcPalErrOk, etcpal_inet_pton(kEtcPalIpTypeV4, test_ip4_1, &addr));
-  TEST_ASSERT_EQUAL(ETCPAL_IP_V4_ADDRESS(&addr), 0u);
-  TEST_ASSERT_EQUAL(kEtcPalErrOk, etcpal_inet_pton(kEtcPalIpTypeV4, test_ip4_2, &addr));
-  TEST_ASSERT_EQUAL(ETCPAL_IP_V4_ADDRESS(&addr), 0xffffffffu);
-  TEST_ASSERT_NOT_EQUAL(kEtcPalErrOk, etcpal_inet_pton(kEtcPalIpTypeV4, test_ip4_fail, &addr));
-  TEST_ASSERT_EQUAL(kEtcPalErrOk, etcpal_inet_pton(kEtcPalIpTypeV6, test_ip6_1, &addr));
-  TEST_ASSERT_EQUAL(0, memcmp(ETCPAL_IP_V6_ADDRESS(&addr), test_ip6_1_bin, ETCPAL_IPV6_BYTES));
-  TEST_ASSERT_EQUAL(kEtcPalErrOk, etcpal_inet_pton(kEtcPalIpTypeV6, test_ip6_2, &addr));
-  TEST_ASSERT_EQUAL(0, memcmp(ETCPAL_IP_V6_ADDRESS(&addr), test_ip6_2_bin, ETCPAL_IPV6_BYTES));
-  TEST_ASSERT_EQUAL(kEtcPalErrOk, etcpal_inet_pton(kEtcPalIpTypeV6, test_ip6_3, &addr));
-  TEST_ASSERT_EQUAL(0, memcmp(ETCPAL_IP_V6_ADDRESS(&addr), test_ip6_3_bin, ETCPAL_IPV6_BYTES));
-  TEST_ASSERT_NOT_EQUAL(kEtcPalErrOk, etcpal_inet_pton(kEtcPalIpTypeV6, test_ip6_fail, &addr));
-
-  // Test etcpal_inet_ntop()
   ETCPAL_IP_SET_V4_ADDRESS(&addr, 0);
-  TEST_ASSERT_EQUAL(kEtcPalErrOk, etcpal_inet_ntop(&addr, str, ETCPAL_INET_ADDRSTRLEN));
+  TEST_ASSERT_EQUAL(kEtcPalErrOk, etcpal_ip_to_string(&addr, str));
   TEST_ASSERT_EQUAL_STRING(str, test_ip4_1);
   ETCPAL_IP_SET_V4_ADDRESS(&addr, 0xffffffff);
-  TEST_ASSERT_EQUAL(kEtcPalErrOk, etcpal_inet_ntop(&addr, str, ETCPAL_INET_ADDRSTRLEN));
+  TEST_ASSERT_EQUAL(kEtcPalErrOk, etcpal_ip_to_string(&addr, str));
   TEST_ASSERT_EQUAL_STRING(str, test_ip4_2);
   ETCPAL_IP_SET_V6_ADDRESS(&addr, test_ip6_1_bin);
-  TEST_ASSERT_EQUAL(kEtcPalErrOk, etcpal_inet_ntop(&addr, str, ETCPAL_INET6_ADDRSTRLEN));
+  TEST_ASSERT_EQUAL(kEtcPalErrOk, etcpal_ip_to_string(&addr, str));
   TEST_ASSERT_EQUAL_STRING(str, test_ip6_1);
   ETCPAL_IP_SET_V6_ADDRESS(&addr, test_ip6_2_bin);
-  TEST_ASSERT_EQUAL(kEtcPalErrOk, etcpal_inet_ntop(&addr, str, ETCPAL_INET6_ADDRSTRLEN));
+  TEST_ASSERT_EQUAL(kEtcPalErrOk, etcpal_ip_to_string(&addr, str));
   TEST_ASSERT_EQUAL_STRING(str, test_ip6_2);
   ETCPAL_IP_SET_V6_ADDRESS(&addr, test_ip6_3_bin);
-  TEST_ASSERT_EQUAL(kEtcPalErrOk, etcpal_inet_ntop(&addr, str, ETCPAL_INET6_ADDRSTRLEN));
+  TEST_ASSERT_EQUAL(kEtcPalErrOk, etcpal_ip_to_string(&addr, str));
   TEST_ASSERT((0 == strcmp(str, "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")) ||
               (0 == strcmp(str, "FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF:FFFF")));
+}
+
+TEST(etcpal_inet, string_to_ip_conversion_works)
+{
+  EtcPalIpAddr addr;
+
+  TEST_ASSERT_EQUAL(kEtcPalErrOk, etcpal_string_to_ip(kEtcPalIpTypeV4, test_ip4_1, &addr));
+  TEST_ASSERT_EQUAL(ETCPAL_IP_V4_ADDRESS(&addr), 0u);
+  TEST_ASSERT_EQUAL(kEtcPalErrOk, etcpal_string_to_ip(kEtcPalIpTypeV4, test_ip4_2, &addr));
+  TEST_ASSERT_EQUAL(ETCPAL_IP_V4_ADDRESS(&addr), 0xffffffffu);
+  TEST_ASSERT_NOT_EQUAL(kEtcPalErrOk, etcpal_string_to_ip(kEtcPalIpTypeV4, test_ip4_fail, &addr));
+  TEST_ASSERT_EQUAL(kEtcPalErrOk, etcpal_string_to_ip(kEtcPalIpTypeV6, test_ip6_1, &addr));
+  TEST_ASSERT_EQUAL(0, memcmp(ETCPAL_IP_V6_ADDRESS(&addr), test_ip6_1_bin, ETCPAL_IPV6_BYTES));
+  TEST_ASSERT_EQUAL(kEtcPalErrOk, etcpal_string_to_ip(kEtcPalIpTypeV6, test_ip6_2, &addr));
+  TEST_ASSERT_EQUAL(0, memcmp(ETCPAL_IP_V6_ADDRESS(&addr), test_ip6_2_bin, ETCPAL_IPV6_BYTES));
+  TEST_ASSERT_EQUAL(kEtcPalErrOk, etcpal_string_to_ip(kEtcPalIpTypeV6, test_ip6_3, &addr));
+  TEST_ASSERT_EQUAL(0, memcmp(ETCPAL_IP_V6_ADDRESS(&addr), test_ip6_3_bin, ETCPAL_IPV6_BYTES));
+  TEST_ASSERT_NOT_EQUAL(kEtcPalErrOk, etcpal_string_to_ip(kEtcPalIpTypeV6, test_ip6_fail, &addr));
 }
 
 TEST(etcpal_inet, mac_is_null_works)
@@ -429,7 +431,7 @@ TEST(etcpal_inet, mac_to_string_conversion_works)
   const EtcPalMacAddr mac = {{1, 2, 3, 4, 5, 6}};
   char str_buf[ETCPAL_MAC_STRING_BYTES];
 
-  etcpal_mac_to_string(&mac, str_buf, ETCPAL_MAC_STRING_BYTES);
+  etcpal_mac_to_string(&mac, str_buf);
   TEST_ASSERT_EQUAL_STRING(str_buf, "01:02:03:04:05:06");
 }
 
@@ -475,7 +477,8 @@ TEST_GROUP_RUNNER(etcpal_inet)
   RUN_TEST_CASE(etcpal_inet, ip_compare_functions_work);
   RUN_TEST_CASE(etcpal_inet, ip_mask_length_works);
   RUN_TEST_CASE(etcpal_inet, ip_mask_from_length_works);
-  RUN_TEST_CASE(etcpal_inet, inet_string_functions_work);
+  RUN_TEST_CASE(etcpal_inet, ip_to_string_conversion_works);
+  RUN_TEST_CASE(etcpal_inet, string_to_ip_conversion_works);
   RUN_TEST_CASE(etcpal_inet, mac_is_null_works);
   RUN_TEST_CASE(etcpal_inet, mac_compare_works);
   RUN_TEST_CASE(etcpal_inet, mac_to_string_conversion_works);

--- a/tests/unit/live/test_netint.c
+++ b/tests/unit/live/test_netint.c
@@ -64,7 +64,7 @@ TEST(etcpal_netint_no_init, api_does_not_work_before_initialization)
   TEST_ASSERT_EQUAL(etcpal_netint_get_default_interface(kEtcPalIpTypeV6, &index), kEtcPalErrNotInit);
 
   EtcPalIpAddr dest;
-  etcpal_inet_pton(kEtcPalIpTypeV4, "8.8.8.8", &dest);
+  etcpal_string_to_ip(kEtcPalIpTypeV4, "8.8.8.8", &dest);
   TEST_ASSERT_EQUAL(etcpal_netint_get_interface_for_dest(&dest, &index), kEtcPalErrNotInit);
 }
 
@@ -215,8 +215,8 @@ TEST(etcpal_netint, get_interface_for_dest_works_ipv4)
     TEST_ASSERT_EQUAL(kEtcPalErrOk, etcpal_netint_get_interface_for_dest(&test_addr, &netint_index_res));
 
     // Put addresses in print form to test meaningful information in case of test failure
-    char test_addr_str[ETCPAL_INET6_ADDRSTRLEN];
-    etcpal_inet_ntop(&test_addr, test_addr_str, ETCPAL_INET6_ADDRSTRLEN);
+    char test_addr_str[ETCPAL_IP_STRING_BYTES];
+    etcpal_ip_to_string(&test_addr, test_addr_str);
     char test_msg[150];
     snprintf(test_msg, 150, "Address tried: %s (interface %u), interface returned: %u", test_addr_str, netint->index,
              netint_index_res);


### PR DESCRIPTION
The functions to convert EtcPal IP addresses to and from string representations have previously been named like their POSIX socket counterparts, with a similar signature:
```
etcpal_inet_ntop()
etcpal_inet_pton()
```

They have been renamed to:
```
etcpal_ip_to_string()
etcpal_string_to_ip()
```

The benefits of this are:
* Better consistency with other module functions which perform the same task:
  + `etcpal_mac_to_string()`
  + `etcpal_uuid_to_string()`
  + etc...
* More immediate understanding of what the functions do from a user who is not familiar with the sockets API
* Better consistency with the C++ counterparts (`IpAddr::ToString()` etc)

Also, the buffer length parameter has been removed from `etcpal_ip_to_string()` and `etcpal_mac_to_string()`. In practice, the macro defining the prescribed buffer size (e.g. `ETCPAL_MAC_STRING_BYTES`, `ETCPAL_IP_STRING_BYTES`) is the only thing ever passed for this parameter, so making the buffer at least that size should just be part of the function's contract.