### PR TITLE
ETCPAL-64 log: Add option to create legacy syslog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ Note: This is a pre-release version. This version changelog is not exhaustive.
 - etcpal/lock: Functions for posting signals and semaphores from an interrupt
   context.
 - etcpal/uuid: Functions to generate version 3 and version 5 UUIDs.
+- etcpal/log: Legacy syslog creation added. Interface changed slightly to
+  support this.
 
 ### Changed
 - Naming: Library name changed from lwpa to EtcPal. All API names updated

--- a/docs/etcpal.tag
+++ b/docs/etcpal.tag
@@ -463,10 +463,10 @@
     <name>EtcPalLogParams</name>
     <filename>struct_etc_pal_log_params.html</filename>
     <member kind="variable">
-      <type>etcpal_log_action_t</type>
+      <type>int</type>
       <name>action</name>
       <anchorfile>struct_etc_pal_log_params.html</anchorfile>
-      <anchor>a97b4c2de584d731ffb8d8ce759930691</anchor>
+      <anchor>a9ba0f2f280a2a2e49c17508af48aad91</anchor>
       <arglist></arglist>
     </member>
     <member kind="variable">
@@ -513,6 +513,13 @@
       <name>syslog</name>
       <anchorfile>struct_etc_pal_log_strings.html</anchorfile>
       <anchor>a5911dbe6a47cb2b9cfbab87a8881b5b6</anchor>
+      <arglist></arglist>
+    </member>
+    <member kind="variable">
+      <type>const char *</type>
+      <name>legacy_syslog</name>
+      <anchorfile>struct_etc_pal_log_strings.html</anchorfile>
+      <anchor>a7c969c4f61944571b31c58080a53f968</anchor>
       <arglist></arglist>
     </member>
     <member kind="variable">
@@ -1470,10 +1477,10 @@
       <arglist>() const noexcept</arglist>
     </member>
     <member kind="function">
-      <type>etcpal_log_action_t</type>
+      <type>int</type>
       <name>log_action</name>
       <anchorfile>classetcpal_1_1_logger.html</anchorfile>
-      <anchor>a5ec18014ab4cbe6b2cf3ce90e8d6737c</anchor>
+      <anchor>a5763d3286470e0ddf797daac285d7e40</anchor>
       <arglist>() const noexcept</arglist>
     </member>
     <member kind="function">
@@ -1529,8 +1536,8 @@
       <type>Logger &amp;</type>
       <name>SetLogAction</name>
       <anchorfile>classetcpal_1_1_logger.html</anchorfile>
-      <anchor>ad947c8fa600d19b89e362aab5405d07a</anchor>
-      <arglist>(etcpal_log_action_t log_action) noexcept</arglist>
+      <anchor>a4ef737dccf9de6bcbeaa668726a4f146</anchor>
+      <arglist>(int log_action) noexcept</arglist>
     </member>
     <member kind="function">
       <type>Logger &amp;</type>
@@ -1659,10 +1666,10 @@
       <arglist>() const noexcept</arglist>
     </member>
     <member kind="function">
-      <type>etcpal_log_action_t</type>
+      <type>int</type>
       <name>log_action</name>
       <anchorfile>classetcpal_1_1_logger.html</anchorfile>
-      <anchor>a5ec18014ab4cbe6b2cf3ce90e8d6737c</anchor>
+      <anchor>a5763d3286470e0ddf797daac285d7e40</anchor>
       <arglist>() const noexcept</arglist>
     </member>
     <member kind="function">
@@ -1718,8 +1725,8 @@
       <type>Logger &amp;</type>
       <name>SetLogAction</name>
       <anchorfile>classetcpal_1_1_logger.html</anchorfile>
-      <anchor>ad947c8fa600d19b89e362aab5405d07a</anchor>
-      <arglist>(etcpal_log_action_t log_action) noexcept</arglist>
+      <anchor>a4ef737dccf9de6bcbeaa668726a4f146</anchor>
+      <arglist>(int log_action) noexcept</arglist>
     </member>
     <member kind="function">
       <type>Logger &amp;</type>
@@ -2485,6 +2492,13 @@
       <anchorfile>classetcpal_1_1_thread.html</anchorfile>
       <anchor>aea418c2372922b6b295e06814c4fe988</anchor>
       <arglist>(int timeout_ms=ETCPAL_WAIT_FOREVER) noexcept</arglist>
+    </member>
+    <member kind="function">
+      <type>Error</type>
+      <name>Terminate</name>
+      <anchorfile>classetcpal_1_1_thread.html</anchorfile>
+      <anchor>a07e5d2b8f7fce024200c4ec8a41c6570</anchor>
+      <arglist>() noexcept</arglist>
     </member>
     <member kind="function">
       <type>unsigned int</type>
@@ -4073,6 +4087,41 @@
       <anchor>gaec05f1fdff3420181c0fe5ae92648e68</anchor>
       <arglist></arglist>
     </member>
+    <member kind="define">
+      <type>#define</type>
+      <name>ETCPAL_LOG_CREATE_HUMAN_READABLE</name>
+      <anchorfile>group__etcpal__log.html</anchorfile>
+      <anchor>ga45d65c059c3b46a251f8ca4141ca1810</anchor>
+      <arglist></arglist>
+    </member>
+    <member kind="define">
+      <type>#define</type>
+      <name>ETCPAL_LOG_CREATE_SYSLOG</name>
+      <anchorfile>group__etcpal__log.html</anchorfile>
+      <anchor>gaf080f0551c3c97b9297429f5d5cbfadc</anchor>
+      <arglist></arglist>
+    </member>
+    <member kind="define">
+      <type>#define</type>
+      <name>ETCPAL_LOG_CREATE_LEGACY_SYSLOG</name>
+      <anchorfile>group__etcpal__log.html</anchorfile>
+      <anchor>ga00ab18ae19f165c3d2b5c54b6c47f936</anchor>
+      <arglist></arglist>
+    </member>
+    <member kind="define">
+      <type>#define</type>
+      <name>ETCPAL_SYSLOG_PARAMS_INIT</name>
+      <anchorfile>group__etcpal__log.html</anchorfile>
+      <anchor>gaa0719223c22e26ee648c97be97ce2aad</anchor>
+      <arglist></arglist>
+    </member>
+    <member kind="define">
+      <type>#define</type>
+      <name>ETCPAL_LOG_PARAMS_INIT</name>
+      <anchorfile>group__etcpal__log.html</anchorfile>
+      <anchor>ga24911b91f9e4d5043348096a3065cd41</anchor>
+      <arglist></arglist>
+    </member>
     <member kind="typedef">
       <type>struct EtcPalLogTimestamp</type>
       <name>EtcPalLogTimestamp</name>
@@ -4115,31 +4164,6 @@
       <anchor>gac6a69c52ee1d8dea2aa9d6a90d217050</anchor>
       <arglist></arglist>
     </member>
-    <member kind="enumeration">
-      <type></type>
-      <name>etcpal_log_action_t</name>
-      <anchorfile>group__etcpal__log.html</anchorfile>
-      <anchor>ga10855f3c1f3816d0bd5e4687108ea1c5</anchor>
-      <arglist></arglist>
-    </member>
-    <member kind="enumvalue">
-      <name>kEtcPalLogCreateSyslog</name>
-      <anchorfile>group__etcpal__log.html</anchorfile>
-      <anchor>gga10855f3c1f3816d0bd5e4687108ea1c5a1631725f7a5f65a9fb15767cecec5290</anchor>
-      <arglist></arglist>
-    </member>
-    <member kind="enumvalue">
-      <name>kEtcPalLogCreateHumanReadable</name>
-      <anchorfile>group__etcpal__log.html</anchorfile>
-      <anchor>gga10855f3c1f3816d0bd5e4687108ea1c5aa0ece7bdc03dd5b29a3be01c212f6b48</anchor>
-      <arglist></arglist>
-    </member>
-    <member kind="enumvalue">
-      <name>kEtcPalLogCreateBoth</name>
-      <anchorfile>group__etcpal__log.html</anchorfile>
-      <anchor>gga10855f3c1f3816d0bd5e4687108ea1c5a8d083dc7d2d4359fd9ce6330b9d4c2bb</anchor>
-      <arglist></arglist>
-    </member>
     <member kind="function">
       <type>bool</type>
       <name>etcpal_create_log_str</name>
@@ -4166,6 +4190,20 @@
       <name>etcpal_vcreate_syslog_str</name>
       <anchorfile>group__etcpal__log.html</anchorfile>
       <anchor>ga943bb13f1d71efce45b30b466e757138</anchor>
+      <arglist>(char *buf, size_t buflen, const EtcPalLogTimestamp *timestamp, const EtcPalSyslogParams *syslog_params, int pri, const char *format, va_list args)</arglist>
+    </member>
+    <member kind="function">
+      <type>bool</type>
+      <name>etcpal_create_legacy_syslog_str</name>
+      <anchorfile>group__etcpal__log.html</anchorfile>
+      <anchor>ga614043c892a15eb55d8695da85db36ca</anchor>
+      <arglist>(char *buf, size_t buflen, const EtcPalLogTimestamp *timestamp, const EtcPalSyslogParams *syslog_params, int pri, const char *format,...)</arglist>
+    </member>
+    <member kind="function">
+      <type>bool</type>
+      <name>etcpal_vcreate_legacy_syslog_str</name>
+      <anchorfile>group__etcpal__log.html</anchorfile>
+      <anchor>ga412dd0f9c14ece292b9bfacdacf90e28</anchor>
       <arglist>(char *buf, size_t buflen, const EtcPalLogTimestamp *timestamp, const EtcPalSyslogParams *syslog_params, int pri, const char *format, va_list args)</arglist>
     </member>
     <member kind="function">

--- a/include/etcpal/cpp/log.h
+++ b/include/etcpal/cpp/log.h
@@ -259,7 +259,7 @@ public:
   /// @{
   LogDispatchPolicy      dispatch_policy() const noexcept;
   int                    log_mask() const noexcept;
-  etcpal_log_action_t    log_action() const noexcept;
+  int                    log_action() const noexcept;
   int                    syslog_facility() const noexcept;
   const char*            syslog_hostname() const noexcept;
   const char*            syslog_app_name() const noexcept;
@@ -271,7 +271,7 @@ public:
   /// @{
   Logger& SetDispatchPolicy(LogDispatchPolicy new_policy) noexcept;
   Logger& SetLogMask(int log_mask) noexcept;
-  Logger& SetLogAction(etcpal_log_action_t log_action) noexcept;
+  Logger& SetLogAction(int log_action) noexcept;
   Logger& SetSyslogFacility(int facility) noexcept;
   Logger& SetSyslogHostname(const char* hostname) noexcept;
   Logger& SetSyslogHostname(const std::string& hostname) noexcept;
@@ -329,7 +329,7 @@ extern "C" inline void LogTimestampFn(void* context, EtcPalLogTimestamp* timesta
 inline Logger::Logger()
 {
   // Default logging parameters
-  log_params_.action = kEtcPalLogCreateHumanReadable;
+  log_params_.action = ETCPAL_LOG_CREATE_HUMAN_READABLE;
   log_params_.log_fn = LogCallbackFn;
   log_params_.log_mask = ETCPAL_LOG_UPTO(ETCPAL_LOG_DEBUG);
   log_params_.time_fn = LogTimestampFn;
@@ -505,7 +505,7 @@ inline int Logger::log_mask() const noexcept
 }
 
 /// @brief Get the current log action.
-inline etcpal_log_action_t Logger::log_action() const noexcept
+inline int Logger::log_action() const noexcept
 {
   return log_params_.action;
 }
@@ -569,7 +569,7 @@ inline Logger& Logger::SetLogMask(int log_mask) noexcept
 }
 
 /// @brief Set the types of log messages to create and dispatch to the LogMessageHandler.
-inline Logger& Logger::SetLogAction(etcpal_log_action_t log_action) noexcept
+inline Logger& Logger::SetLogAction(int log_action) noexcept
 {
   log_params_.action = log_action;
   return *this;

--- a/include/etcpal/log.h
+++ b/include/etcpal/log.h
@@ -22,6 +22,7 @@
 #ifndef ETCPAL_LOG_H_
 #define ETCPAL_LOG_H_
 
+#include <limits.h>
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -102,14 +103,18 @@
  * }
  *
  * // In an init function of some kind...
- * EtcPalLogParams log_params;
- * log_params.action = kEtcPalLogCreateHumanReadable;
+ * EtcPalLogParams log_params = ETCPAL_LOG_PARAMS_INIT;
+ * log_params.action = ETCPAL_LOG_CREATE_HUMAN_READABLE;
  * log_params.log_mask = ETCPAL_LOG_UPTO(ETCPAL_LOG_INFO); // Log up to and including INFO, excluding DEBUG.
  * log_params.log_fn = my_log_callback;
  * log_params.time_fn = my_time_callback;
- * log_params.context = NULL;
- * // If we set action to kEtcPalLogCreateSyslog or kEtcPalLogCreateBoth, we would also initialize
- * // log_params.syslog_params here.
+ *
+ * // action is a bitmask representing the type of header(s) to create for each log message. For
+ * // example, to create both a human-readable and syslog header:
+ * log_params.action = ETCPAL_LOG_CREATE_HUMAN_READABLE | ETCPAL_LOG_CREATE_SYSLOG;
+ * log_params.syslog_params.facility = ETCPAL_LOG_USER;
+ * strcpy(log_params.syslog_params.hostname, my_ip_addr_string);
+ * strcpy(log_params.syslog_params.app_name, "My App");
  *
  * // Pass to some library, maybe...
  * somelib_init(&log_params);
@@ -193,7 +198,8 @@
 
 /* clang-format on */
 
-/* Timestamp length:
+/*
+ * Timestamp length:
  * Date:       10 (1970-01-01)
  * "T" or " ":  1
  * Time:       12 (00:00:00.001)
@@ -205,7 +211,8 @@
 /** The maximum length of the timestamp used in syslog and human-readable logging. */
 #define ETCPAL_LOG_TIMESTAMP_LEN 30u
 
-/* Syslog header length (from RFC 5424):
+/*
+ * Syslog header length (from RFC 5424):
  * PRIVAL:                     5
  * VERSION:                    3
  * SP:                         1
@@ -246,8 +253,10 @@
  * ----------------------------
  * Total non-referenced:      8
  */
-/** The maximum length of a string that will be passed via the human_readable member of an
- *  EtcPalLogStrings struct. */
+/**
+ * The maximum length of a string that will be passed via the human_readable member of an
+ * EtcPalLogStrings struct.
+ */
 #define ETCPAL_LOG_STR_MAX_LEN (8u + (ETCPAL_LOG_TIMESTAMP_LEN - 1u) + ETCPAL_RAW_LOG_MSG_MAX_LEN)
 
 /**
@@ -266,19 +275,27 @@ typedef struct EtcPalLogTimestamp
   int          utc_offset; /**< The local offset from UTC in minutes. */
 } EtcPalLogTimestamp;
 
-/** The set of log strings passed with a call to an etcpal_log_callback function. Any members not
- *  requested in the corresponding EtcPalLogParams struct will be NULL. */
+/**
+ * @brief The set of log strings passed with a call to an etcpal_log_callback function.
+ * @details Any members not requested in the corresponding EtcPalLogParams struct will be NULL.
+ */
 typedef struct EtcPalLogStrings
 {
   /** Log string formatted compliant to RFC 5424. */
   const char* syslog;
+  /** Log string formatted compliant to RFC 3164. */
+  const char* legacy_syslog;
   /** Log string formatted for readability per ETC convention. */
   const char* human_readable;
-  /** The original log string that was passed to etcpal_log() or etcpal_vlog(). Will overlap with
-   *  one of syslog_str or human_str. */
+  /**
+   * The original log string that was passed to etcpal_log() or etcpal_vlog(). Will overlap with
+   * one of the strings above.
+   */
   const char* raw;
-  /** The original log priority that was passed to etcpal_log() or etcpal_vlog(). Useful if this
-   *  log message is being passed to a system syslog daemon. */
+  /**
+   * The original log priority that was passed to etcpal_log() or etcpal_vlog(). Useful if this log
+   * message is being passed to a system syslog daemon.
+   */
   int priority;
 } EtcPalLogStrings;
 
@@ -314,58 +331,78 @@ typedef void (*EtcPalLogCallback)(void* context, const EtcPalLogStrings* strings
  */
 typedef void (*EtcPalLogTimeFn)(void* context, EtcPalLogTimestamp* timestamp);
 
-/** Which types of log message(s) the etcpal_log() and etcpal_vlog() functions create. */
-typedef enum
-{
-  /** etcpal_log() and etcpal_vlog() create a syslog message and pass it back in the
-   *  strings->syslog parameter of the log callback. */
-  kEtcPalLogCreateSyslog,
-  /** etcpal_log() and etcpal_vlog() create a human-readable log message and pass it back in the
-   *  strings->human_readable parameter of the log callback. */
-  kEtcPalLogCreateHumanReadable,
-  /** etcpal_log() and etcpal_vlog() create both a syslog message and a human-readable log message
-   *  and pass them back in the strings->syslog and strings->human_readable parameters of the log
-   *  callback. */
-  kEtcPalLogCreateBoth
-} etcpal_log_action_t;
+/** Create a log string with a human-readable prefix including timestamp and severity. */
+#define ETCPAL_LOG_CREATE_HUMAN_READABLE 0x01
+/** Create a log string with a header that complies with RFC 5424. */
+#define ETCPAL_LOG_CREATE_SYSLOG 0x02
+/** Create a log string with a header that complies with RFC 3164. */
+#define ETCPAL_LOG_CREATE_LEGACY_SYSLOG 0x04
 
 /** A set of parameters for the syslog header. */
 typedef struct EtcPalSyslogParams
 {
-  /** Syslog Facility; see RFC 5424 &sect; 6.2.1. */
-  int facility;
-  /** Syslog HOSTNAME; see RFC 5424 &sect; 6.2.4. */
-  char hostname[ETCPAL_LOG_HOSTNAME_MAX_LEN];
-  /** Syslog APP-NAME; see RFC 5424 &sect; 6.2.5. */
-  char app_name[ETCPAL_LOG_APP_NAME_MAX_LEN];
-  /** Syslog PROCID; see RFC 5424 &sect; 6.2.6. */
-  char procid[ETCPAL_LOG_PROCID_MAX_LEN];
+  int  facility;                              /**< Syslog Facility; see RFC 5424 &sect; 6.2.1. */
+  char hostname[ETCPAL_LOG_HOSTNAME_MAX_LEN]; /**< Syslog HOSTNAME; see RFC 5424 &sect; 6.2.4. */
+  char app_name[ETCPAL_LOG_APP_NAME_MAX_LEN]; /**< Syslog APP-NAME; see RFC 5424 &sect; 6.2.5. */
+  char procid[ETCPAL_LOG_PROCID_MAX_LEN];     /**< Syslog PROCID; see RFC 5424 &sect; 6.2.6. */
 } EtcPalSyslogParams;
+
+/**
+ * @brief A default-value initializer for an EtcPalSyslogParams struct.
+ *
+ * Usage:
+ * @code
+ * EtcPalSyslogParams params = ETCPAL_SYSLOG_PARAMS_INIT;
+ * // Now fill in the relevant portions as necessary with your data...
+ * @endcode
+ */
+#define ETCPAL_SYSLOG_PARAMS_INIT \
+  {                               \
+    0, {'\0'}, {'\0'}, { '\0' }   \
+  }
 
 /** A set of parameters used for the etcpal_*log() functions. */
 typedef struct EtcPalLogParams
 {
   /** What should be done when etcpal_log() or etcpal_vlog() is called. */
-  etcpal_log_action_t action;
+  int action;
   /** A callback function for the finished log string(s). */
   EtcPalLogCallback log_fn;
   /** The syslog header parameters. */
   EtcPalSyslogParams syslog_params;
   /** A mask value that determines which priority messages can be logged. */
   int log_mask;
-  /** A callback function for the etcpal_log() and etcpal_vlog() functions to obtain the time from the
-   *  application. If NULL, no timestamp will be added to log messages. */
+  /**
+   * A callback function for the etcpal_log() and etcpal_vlog() functions to obtain the time from
+   * the application. If NULL, no timestamp will be added to log messages.
+   */
   EtcPalLogTimeFn time_fn;
   /** Application context that will be passed back with the log callback function. */
   void* context;
 } EtcPalLogParams;
 
+/**
+ * @brief A default-value initializer for an EtcPalLogParams struct.
+ *
+ * Usage:
+ * @code
+ * EtcPalLogParams params = ETCPAL_LOG_PARAMS_INIT;
+ * // Now fill in the relevant portions as necessary with your data...
+ * @endcode
+ */
+#define ETCPAL_LOG_PARAMS_INIT                        \
+  {                                                   \
+    0, NULL, ETCPAL_SYSLOG_PARAMS_INIT, 0, NULL, NULL \
+  }
+
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-/* The various compiler ifdefs are to use each compiler's method of checking printf-style
- * arguments. */
+/*
+ * The various compiler ifdefs are to use each compiler's method of checking printf-style
+ * arguments.
+ */
 
 #ifdef __ICCARM__
 #pragma __printf_args
@@ -410,6 +447,29 @@ bool etcpal_vcreate_syslog_str(char*                     buf,
                                int                       pri,
                                const char*               format,
                                va_list                   args);
+
+#ifdef __ICCARM__
+#pragma __printf_args
+#endif
+bool etcpal_create_legacy_syslog_str(char*                     buf,
+                                     size_t                    buflen,
+                                     const EtcPalLogTimestamp* timestamp,
+                                     const EtcPalSyslogParams* syslog_params,
+                                     int                       pri,
+                                     const char*               format,
+                                     ...)
+#ifdef __GNUC__
+    __attribute__((__format__(__printf__, 6, 7)))
+#endif
+    ;
+
+bool etcpal_vcreate_legacy_syslog_str(char*                     buf,
+                                      size_t                    buflen,
+                                      const EtcPalLogTimestamp* timestamp,
+                                      const EtcPalSyslogParams* syslog_params,
+                                      int                       pri,
+                                      const char*               format,
+                                      va_list                   args);
 
 void etcpal_sanitize_syslog_params(EtcPalSyslogParams* params);
 bool etcpal_validate_log_params(EtcPalLogParams* params);

--- a/include/etcpal/log.h
+++ b/include/etcpal/log.h
@@ -69,6 +69,10 @@
  * library available. When such libraries are present, they handle formatting and building the
  * header and thus this function should not be used.
  *
+ * The module also supports building a syslog format compliant with RFC 3164 (referred to here as
+ * "legacy syslog") for legacy product support. The RFC 3164 format is obsoleted by RFC 5424, and
+ * use of the legacy syslog format is not recommended in new code.
+ *
  * @code
  * EtcPalSyslogParams my_syslog_params;
  * my_syslog_params.facility = ETCPAL_LOG_LOCAL1;
@@ -244,7 +248,8 @@
 /** The maximum length of a syslog string that will be passed to an etcpal_log_callback function. */
 #define ETCPAL_SYSLOG_STR_MAX_LEN (ETCPAL_SYSLOG_HEADER_MAX_LEN + ETCPAL_RAW_LOG_MSG_MAX_LEN)
 
-/* Human-reaadable log string max length:
+/*
+ * Human-reaadable log string max length:
  * Timestamp:      [Referenced]
  * Space:                     1
  * Priority:                  6 ([CRIT])

--- a/tests/unit/cpp/test_log.cpp
+++ b/tests/unit/cpp/test_log.cpp
@@ -123,7 +123,7 @@ TEST(etcpal_cpp_log, startup_works)
 
   // Startup should work - after starting, logging should work
   TEST_ASSERT_TRUE(logger.SetDispatchPolicy(etcpal::LogDispatchPolicy::Direct)
-                       .SetLogAction(kEtcPalLogCreateHumanReadable)
+                       .SetLogAction(ETCPAL_LOG_CREATE_HUMAN_READABLE)
                        .Startup(test_log_handler));
 
   logger.Debug("Test Message");
@@ -136,18 +136,18 @@ TEST(etcpal_cpp_log, startup_works)
 // Test the dispatch_policy, log_action and log_params setters/getters
 TEST(etcpal_cpp_log, basic_getters_work)
 {
-  logger.SetDispatchPolicy(etcpal::LogDispatchPolicy::Direct).SetLogAction(kEtcPalLogCreateSyslog);
+  logger.SetDispatchPolicy(etcpal::LogDispatchPolicy::Direct).SetLogAction(ETCPAL_LOG_CREATE_SYSLOG);
 
   TEST_ASSERT_EQUAL(logger.dispatch_policy(), etcpal::LogDispatchPolicy::Direct);
-  TEST_ASSERT_EQUAL(logger.log_action(), kEtcPalLogCreateSyslog);
-  TEST_ASSERT_EQUAL(logger.log_params().action, kEtcPalLogCreateSyslog);
+  TEST_ASSERT_EQUAL(logger.log_action(), ETCPAL_LOG_CREATE_SYSLOG);
+  TEST_ASSERT_EQUAL(logger.log_params().action, ETCPAL_LOG_CREATE_SYSLOG);
 }
 
 // Test the functionality of the log mask.
 TEST(etcpal_cpp_log, log_mask_works)
 {
   TEST_ASSERT_TRUE(logger.SetDispatchPolicy(etcpal::LogDispatchPolicy::Direct)
-                       .SetLogAction(kEtcPalLogCreateHumanReadable)
+                       .SetLogAction(ETCPAL_LOG_CREATE_HUMAN_READABLE)
                        .Startup(test_log_handler));
 
   logger.SetLogMask(ETCPAL_LOG_UPTO(ETCPAL_LOG_WARNING));
@@ -192,7 +192,7 @@ TEST(etcpal_cpp_log, log_mask_works)
 TEST(etcpal_cpp_log, log_functions_work)
 {
   TEST_ASSERT_TRUE(logger.SetDispatchPolicy(etcpal::LogDispatchPolicy::Direct)
-                       .SetLogAction(kEtcPalLogCreateHumanReadable)
+                       .SetLogAction(ETCPAL_LOG_CREATE_HUMAN_READABLE)
                        .Startup(test_log_handler));
 
   std::string human_str;
@@ -261,7 +261,7 @@ TEST(etcpal_cpp_log, log_functions_work)
 TEST(etcpal_cpp_log, timestamps_work)
 {
   TEST_ASSERT_TRUE(logger.SetDispatchPolicy(etcpal::LogDispatchPolicy::Direct)
-                       .SetLogAction(kEtcPalLogCreateHumanReadable)
+                       .SetLogAction(ETCPAL_LOG_CREATE_HUMAN_READABLE)
                        .Startup(test_log_handler));
 
   // January 22, 2020 16:57:33.123 UTC-06:00
@@ -291,7 +291,7 @@ TEST(etcpal_cpp_log, syslog_params_work)
                        .SetSyslogAppName("TestApp")
                        .SetSyslogProcId(200)
                        .SetDispatchPolicy(etcpal::LogDispatchPolicy::Direct)
-                       .SetLogAction(kEtcPalLogCreateSyslog)
+                       .SetLogAction(ETCPAL_LOG_CREATE_SYSLOG | ETCPAL_LOG_CREATE_LEGACY_SYSLOG)
                        .Startup(test_log_handler));
 
   TEST_ASSERT_EQUAL_INT(logger.syslog_facility(), ETCPAL_LOG_LOCAL1);
@@ -300,9 +300,14 @@ TEST(etcpal_cpp_log, syslog_params_work)
   TEST_ASSERT_EQUAL_STRING(logger.syslog_procid(), "200");
 
   std::string syslog_str;
-  test_log_handler.OnLogEvent([&syslog_str](const EtcPalLogStrings& strings) { syslog_str = strings.syslog; });
+  std::string legacy_syslog_str;
+  test_log_handler.OnLogEvent([&](const EtcPalLogStrings& strings) {
+    syslog_str = strings.syslog;
+    legacy_syslog_str = strings.legacy_syslog;
+  });
   logger.Log(ETCPAL_LOG_INFO, "Test Message");
   TEST_ASSERT_EQUAL_STRING(syslog_str.c_str(), "<142>1 1970-01-01T00:00:00.000Z MyHost TestApp 200 - - Test Message");
+  TEST_ASSERT_EQUAL_STRING(legacy_syslog_str.c_str(), "<142>Jan  1 00:00:00 MyHost TestApp[200]: Test Message");
 }
 
 TEST(etcpal_cpp_log, queued_dispatch_works)
@@ -314,7 +319,7 @@ TEST(etcpal_cpp_log, queued_dispatch_works)
 
   // Startup should work - after starting, logging should work
   TEST_ASSERT_TRUE(logger.SetDispatchPolicy(etcpal::LogDispatchPolicy::Queued)
-                       .SetLogAction(kEtcPalLogCreateHumanReadable)
+                       .SetLogAction(ETCPAL_LOG_CREATE_HUMAN_READABLE)
                        .SetLogMask(ETCPAL_LOG_UPTO(ETCPAL_LOG_DEBUG))
                        .Startup(test_log_handler));
 

--- a/tests/unit/live/test_common.c
+++ b/tests/unit/live/test_common.c
@@ -76,12 +76,10 @@ TEST(etcpal_common, log_double_init_works)
   TEST_ASSERT_EQUAL(kEtcPalErrOk, etcpal_init(ETCPAL_FEATURE_LOGGING));
   TEST_ASSERT_EQUAL(kEtcPalErrOk, etcpal_init(ETCPAL_FEATURE_LOGGING));
 
-  EtcPalLogParams params;
-  params.action = kEtcPalLogCreateHumanReadable;
+  EtcPalLogParams params = ETCPAL_LOG_PARAMS_INIT;
+  params.action = ETCPAL_LOG_CREATE_HUMAN_READABLE;
   params.log_fn = common_test_log_callback;
   params.log_mask = ETCPAL_LOG_UPTO(ETCPAL_LOG_DEBUG);
-  params.time_fn = NULL;
-  params.context = NULL;
 
   TEST_ASSERT_TRUE(etcpal_validate_log_params(&params));
 


### PR DESCRIPTION
* Log action changed to bitmask from enum
* Two new functions to create legacy syslog strings directly
* legacy_syslog member added to EtcPalLogStrings
* Full test coverage