### PR TITLE
Fix potential unaligned access issue on ARM/Thumb architecture

### DIFF
--- a/src/etcpal/inet.c
+++ b/src/etcpal/inet.c
@@ -379,6 +379,9 @@ EtcPalIpAddr etcpal_ip_mask_from_length(etcpal_iptype_t type, unsigned int mask_
  */
 bool etcpal_ip_network_portions_equal(const EtcPalIpAddr* ip1, const EtcPalIpAddr* ip2, const EtcPalIpAddr* netmask)
 {
+  if (!ip1 || !ip2 || !netmask)
+    return false;
+
   if (ETCPAL_IP_IS_V4(ip1) && ETCPAL_IP_IS_V4(ip2) && ETCPAL_IP_IS_V4(netmask))
   {
     return ((ETCPAL_IP_V4_ADDRESS(ip1) & ETCPAL_IP_V4_ADDRESS(netmask)) ==
@@ -386,12 +389,12 @@ bool etcpal_ip_network_portions_equal(const EtcPalIpAddr* ip1, const EtcPalIpAdd
   }
   else if (ETCPAL_IP_IS_V6(ip1) && ETCPAL_IP_IS_V6(ip2) && ETCPAL_IP_IS_V6(netmask))
   {
-    size_t          i;
-    const uint32_t* p1 = (const uint32_t*)ETCPAL_IP_V6_ADDRESS(ip1);
-    const uint32_t* p2 = (const uint32_t*)ETCPAL_IP_V6_ADDRESS(ip2);
-    const uint32_t* pm = (const uint32_t*)ETCPAL_IP_V6_ADDRESS(netmask);
+    size_t         i;
+    const uint8_t* p1 = ETCPAL_IP_V6_ADDRESS(ip1);
+    const uint8_t* p2 = ETCPAL_IP_V6_ADDRESS(ip2);
+    const uint8_t* pm = ETCPAL_IP_V6_ADDRESS(netmask);
 
-    for (i = 0; i < ETCPAL_IPV6_BYTES / 4; ++i, ++p1, ++p2, ++pm)
+    for (i = 0; i < ETCPAL_IPV6_BYTES; ++i, ++p1, ++p2, ++pm)
     {
       if ((*p1 & *pm) != (*p2 & *pm))
         return false;

--- a/tests/unit/live/test_inet.c
+++ b/tests/unit/live/test_inet.c
@@ -349,6 +349,64 @@ TEST(etcpal_inet, ip_mask_from_length_works)
   TEST_ASSERT_EQUAL_UINT8_ARRAY(ETCPAL_IP_V6_ADDRESS(&mask_out), v6_compare_val, ETCPAL_IPV6_BYTES);
 }
 
+TEST(etcpal_inet, ip_network_portions_equal_invalid_calls_fail)
+{
+  // NULL parameters
+  TEST_ASSERT_FALSE(etcpal_ip_network_portions_equal(NULL, NULL, NULL));
+
+  // Contrasting IP types
+  EtcPalIpAddr addr1;
+  EtcPalIpAddr addr2;
+  ETCPAL_IP_SET_V4_ADDRESS(&addr1, 0xc0a80101);
+  ETCPAL_IP_SET_V4_ADDRESS(&addr2, 0xc0a80102);
+  EtcPalIpAddr mask = etcpal_ip_mask_from_length(kEtcPalIpTypeV6, 64);
+
+  TEST_ASSERT_FALSE(etcpal_ip_network_portions_equal(&addr1, &addr2, &mask));
+}
+
+TEST(etcpal_inet, ip_network_portions_equal_works_ipv4)
+{
+  EtcPalIpAddr addr1;
+  EtcPalIpAddr addr2;
+  EtcPalIpAddr mask;
+
+  ETCPAL_IP_SET_V4_ADDRESS(&addr1, 0xa5a50011);
+  ETCPAL_IP_SET_V4_ADDRESS(&addr2, 0xa5a51100);
+  ETCPAL_IP_SET_V4_ADDRESS(&mask, 0xffff0000);
+
+  TEST_ASSERT_TRUE(etcpal_ip_network_portions_equal(&addr1, &addr2, &mask));
+
+  ETCPAL_IP_SET_V4_ADDRESS(&mask, 0xffffff00);
+  TEST_ASSERT_FALSE(etcpal_ip_network_portions_equal(&addr1, &addr2, &mask));
+
+  ETCPAL_IP_SET_V4_ADDRESS(&mask, 0);
+  TEST_ASSERT_TRUE(etcpal_ip_network_portions_equal(&addr1, &addr2, &mask));
+
+  ETCPAL_IP_SET_V4_ADDRESS(&mask, 0xffffffff);
+  TEST_ASSERT_FALSE(etcpal_ip_network_portions_equal(&addr1, &addr2, &mask));
+}
+
+TEST(etcpal_inet, ip_network_portions_equal_works_ipv6)
+{
+  EtcPalIpAddr addr1;
+  EtcPalIpAddr addr2;
+
+  etcpal_string_to_ip(kEtcPalIpTypeV6, "2001:db8::1234:5678", &addr1);
+  etcpal_string_to_ip(kEtcPalIpTypeV6, "2001:db8::8765:4321", &addr2);
+  EtcPalIpAddr mask = etcpal_ip_mask_from_length(kEtcPalIpTypeV6, 64);
+
+  TEST_ASSERT_TRUE(etcpal_ip_network_portions_equal(&addr1, &addr2, &mask));
+
+  mask = etcpal_ip_mask_from_length(kEtcPalIpTypeV6, 112);
+  TEST_ASSERT_FALSE(etcpal_ip_network_portions_equal(&addr1, &addr2, &mask));
+
+  mask = etcpal_ip_mask_from_length(kEtcPalIpTypeV6, 0);
+  TEST_ASSERT_TRUE(etcpal_ip_network_portions_equal(&addr1, &addr2, &mask));
+
+  mask = etcpal_ip_mask_from_length(kEtcPalIpTypeV6, 128);
+  TEST_ASSERT_FALSE(etcpal_ip_network_portions_equal(&addr1, &addr2, &mask));
+}
+
 // For ip/string functions
 char          str[ETCPAL_IP_STRING_BYTES];
 const char*   test_ip4_1 = "0.0.0.0";
@@ -477,6 +535,9 @@ TEST_GROUP_RUNNER(etcpal_inet)
   RUN_TEST_CASE(etcpal_inet, ip_compare_functions_work);
   RUN_TEST_CASE(etcpal_inet, ip_mask_length_works);
   RUN_TEST_CASE(etcpal_inet, ip_mask_from_length_works);
+  RUN_TEST_CASE(etcpal_inet, ip_network_portions_equal_invalid_calls_fail);
+  RUN_TEST_CASE(etcpal_inet, ip_network_portions_equal_works_ipv4);
+  RUN_TEST_CASE(etcpal_inet, ip_network_portions_equal_works_ipv6);
   RUN_TEST_CASE(etcpal_inet, ip_to_string_conversion_works);
   RUN_TEST_CASE(etcpal_inet, string_to_ip_conversion_works);
   RUN_TEST_CASE(etcpal_inet, mac_is_null_works);


### PR DESCRIPTION
* Don't cast byte buffers to uint32_t in etcpal_ip_network_portions_equal()
* Add tests for etcpal_ip_network_portions_equal()