### PR TITLE
Red-black tree etcpal_rbiter_lower_bound and etcpal_rbiter_upper_bound functions

### DIFF
--- a/include/etcpal/rbtree.h
+++ b/include/etcpal/rbtree.h
@@ -258,6 +258,8 @@ void*         etcpal_rbiter_first(EtcPalRbIter* self, EtcPalRbTree* tree);
 void*         etcpal_rbiter_last(EtcPalRbIter* self, EtcPalRbTree* tree);
 void*         etcpal_rbiter_next(EtcPalRbIter* self);
 void*         etcpal_rbiter_prev(EtcPalRbIter* self);
+void*         etcpal_rbiter_lower_bound(EtcPalRbIter* self, EtcPalRbTree* tree, const void* value);
+void*         etcpal_rbiter_upper_bound(EtcPalRbIter* self, EtcPalRbTree* tree, const void* value);
 
 #ifdef __cplusplus
 }

--- a/include/etcpal/rbtree.h
+++ b/include/etcpal/rbtree.h
@@ -258,8 +258,8 @@ void*         etcpal_rbiter_first(EtcPalRbIter* self, EtcPalRbTree* tree);
 void*         etcpal_rbiter_last(EtcPalRbIter* self, EtcPalRbTree* tree);
 void*         etcpal_rbiter_next(EtcPalRbIter* self);
 void*         etcpal_rbiter_prev(EtcPalRbIter* self);
-void*         etcpal_rbiter_lower_bound(EtcPalRbIter* self, EtcPalRbTree* tree, const void* value);
-void*         etcpal_rbiter_upper_bound(EtcPalRbIter* self, EtcPalRbTree* tree, const void* value);
+void*         etcpal_rbiter_lower_bound(EtcPalRbIter* self, const EtcPalRbTree* tree, const void* value);
+void*         etcpal_rbiter_upper_bound(EtcPalRbIter* self, const EtcPalRbTree* tree, const void* value);
 
 #ifdef __cplusplus
 }

--- a/include/etcpal/rbtree.h
+++ b/include/etcpal/rbtree.h
@@ -258,8 +258,8 @@ void*         etcpal_rbiter_first(EtcPalRbIter* self, EtcPalRbTree* tree);
 void*         etcpal_rbiter_last(EtcPalRbIter* self, EtcPalRbTree* tree);
 void*         etcpal_rbiter_next(EtcPalRbIter* self);
 void*         etcpal_rbiter_prev(EtcPalRbIter* self);
-void*         etcpal_rbiter_lower_bound(EtcPalRbIter* self, const EtcPalRbTree* tree, const void* value);
-void*         etcpal_rbiter_upper_bound(EtcPalRbIter* self, const EtcPalRbTree* tree, const void* value);
+void*         etcpal_rbiter_lower_bound(EtcPalRbIter* self, EtcPalRbTree* tree, const void* value);
+void*         etcpal_rbiter_upper_bound(EtcPalRbIter* self, EtcPalRbTree* tree, const void* value);
 
 #ifdef __cplusplus
 }

--- a/src/etcpal/rbtree.c
+++ b/src/etcpal/rbtree.c
@@ -800,7 +800,7 @@ void* etcpal_rbiter_lower_bound(EtcPalRbIter* self, EtcPalRbTree* tree, const vo
       {
         // If cmp == 0, then the current node is equal to the value. If cmp > 0, then the current node goes after the
         // value. In either case, the previous node (if any) goes before the value.
-        result = self->node;
+        result = self->node->value;
       }
     }
   }
@@ -831,7 +831,7 @@ void* etcpal_rbiter_upper_bound(EtcPalRbIter* self, EtcPalRbTree* tree, const vo
       if (cmp > 0)
       {
         // The current node goes after the value. The previous node (if any) goes before the value.
-        result = self->node;
+        result = self->node->value;
       }
       else
       {

--- a/src/etcpal/rbtree.c
+++ b/src/etcpal/rbtree.c
@@ -836,7 +836,7 @@ void* etcpal_rbiter_upper_bound(EtcPalRbIter* self, const EtcPalRbTree* tree, co
       else
       {
         // If cmp == 0, then the current node is equal to the value, but not after. If cmp < 0, then the current node
-        // goes before the value. In either case, the next node goes after the value.
+        // goes before the value. In either case, the next node goes after the value (there are no duplicates).
         result = etcpal_rbiter_next(self);
       }
     }

--- a/src/etcpal/rbtree.c
+++ b/src/etcpal/rbtree.c
@@ -748,3 +748,31 @@ void* etcpal_rbiter_prev(EtcPalRbIter* self)
 {
   return rb_iter_move(self, 0);
 }
+
+/**
+ * @brief Point a red-black tree iterator to the lower-bound of a value.
+ *
+ * Gets the first value in the tree that is not considered to go before the given value.
+ *
+ * @param[in] self Iterator to modify.
+ * @param[in] tree Tree of which to get the lower bound.
+ * @return Pointer to the lower bound value, or NULL (the end of the tree has been reached).
+ */
+void* etcpal_rbiter_lower_bound(EtcPalRbIter* self, EtcPalRbTree* tree, const void* value)
+{
+  return NULL;  // TODO: Implement this.
+}
+
+/**
+ * @brief Point a red-black tree iterator to the upper-bound of a value.
+ *
+ * Gets the first value in the tree that is considered to go after the given value.
+ *
+ * @param[in] self Iterator to modify.
+ * @param[in] tree Tree of which to get the upper bound.
+ * @return Pointer to the upper bound value, or NULL (the end of the tree has been reached).
+ */
+void* etcpal_rbiter_upper_bound(EtcPalRbIter* self, EtcPalRbTree* tree, const void* value)
+{
+  return NULL;  // TODO: Implement this.
+}

--- a/src/etcpal/rbtree.c
+++ b/src/etcpal/rbtree.c
@@ -169,6 +169,33 @@ EtcPalRbTree* etcpal_rbtree_init(EtcPalRbTree*           self,
   return self;
 }
 
+/* Iterate the tree in a binary search pattern as far as it can go. Returns the final comparison result. */
+static int rb_iter_binary_search(EtcPalRbIter* self, const EtcPalRbTree* tree, const void* value)
+{
+  int cmp = 0;
+
+  self->tree = tree;
+  self->node = tree->root;
+  self->top = 0;
+
+  if (self->node)
+  {
+    cmp = tree->cmp(tree, self->node->value, value);
+
+    while ((cmp != 0) && (self->node->link[cmp < 0] != NULL))
+    {
+      /* If the tree supports duplicates, they should be chained to the right subtree for this to
+       * work */
+      self->path[self->top++] = self->node;
+      self->node = self->node->link[cmp < 0];
+
+      cmp = tree->cmp(tree, self->node->value, value);
+    }
+  }
+
+  return cmp;
+}
+
 /**
  * @brief Find a value in a red-black tree.
  *
@@ -684,33 +711,6 @@ static void* rb_iter_move(EtcPalRbIter* self, int dir)
     } while (last == self->node->link[dir]);
   }
   return self->node == NULL ? NULL : self->node->value;
-}
-
-/* Iterate the tree in a binary search pattern as far as it can go. Returns the final comparison result. */
-static int rb_iter_binary_search(EtcPalRbIter* self, const EtcPalRbTree* tree, const void* value)
-{
-  int cmp = 0;
-
-  self->tree = tree;
-  self->node = tree->root;
-  self->top = 0;
-
-  if (self->node)
-  {
-    cmp = tree->cmp(tree, self->node->value, value);
-
-    while ((cmp != 0) && (self->node->link[cmp < 0] != NULL))
-    {
-      /* If the tree supports duplicates, they should be chained to the right subtree for this to
-       * work */
-      self->path[self->top++] = self->node;
-      self->node = self->node->link[cmp < 0];
-
-      cmp = tree->cmp(tree, self->node->value, value);
-    }
-  }
-
-  return cmp;
 }
 
 /**

--- a/src/etcpal/rbtree.c
+++ b/src/etcpal/rbtree.c
@@ -692,7 +692,7 @@ static void* rb_iter_move(EtcPalRbIter* self, int dir)
 }
 
 /* Iterate the tree in a binary search pattern as far as it can go. Returns the final comparison result. */
-static int rb_iter_binary_search(EtcPalRbIter* self, EtcPalRbTree* tree, const void* value)
+static int rb_iter_binary_search(EtcPalRbIter* self, const EtcPalRbTree* tree, const void* value)
 {
   int cmp = 0;
 
@@ -783,9 +783,10 @@ void* etcpal_rbiter_prev(EtcPalRbIter* self)
  *
  * @param[in] self Iterator to modify.
  * @param[in] tree Tree of which to get the lower bound.
+ * @param[in] value The value to compare against to determine the lower bound.
  * @return Pointer to the lower bound value, or NULL (the end of the tree has been reached).
  */
-void* etcpal_rbiter_lower_bound(EtcPalRbIter* self, EtcPalRbTree* tree, const void* value)
+void* etcpal_rbiter_lower_bound(EtcPalRbIter* self, const EtcPalRbTree* tree, const void* value)
 {
   void* result = NULL;
 
@@ -819,9 +820,10 @@ void* etcpal_rbiter_lower_bound(EtcPalRbIter* self, EtcPalRbTree* tree, const vo
  *
  * @param[in] self Iterator to modify.
  * @param[in] tree Tree of which to get the upper bound.
+ * @param[in] value The value to compare against to determine the upper bound.
  * @return Pointer to the upper bound value, or NULL (the end of the tree has been reached).
  */
-void* etcpal_rbiter_upper_bound(EtcPalRbIter* self, EtcPalRbTree* tree, const void* value)
+void* etcpal_rbiter_upper_bound(EtcPalRbIter* self, const EtcPalRbTree* tree, const void* value)
 {
   void* result = NULL;
 

--- a/src/etcpal/rbtree.c
+++ b/src/etcpal/rbtree.c
@@ -170,7 +170,7 @@ EtcPalRbTree* etcpal_rbtree_init(EtcPalRbTree*           self,
 }
 
 /* Iterate the tree in a binary search pattern as far as it can go. Returns the final comparison result. */
-static int rb_iter_binary_search(EtcPalRbIter* self, const EtcPalRbTree* tree, const void* value)
+static int rb_iter_binary_search(EtcPalRbIter* self, EtcPalRbTree* tree, const void* value)
 {
   int cmp = 0;
 
@@ -781,7 +781,7 @@ void* etcpal_rbiter_prev(EtcPalRbIter* self)
  * @param[in] value The value to compare against to determine the lower bound.
  * @return Pointer to the lower bound value, or NULL (the end of the tree has been reached).
  */
-void* etcpal_rbiter_lower_bound(EtcPalRbIter* self, const EtcPalRbTree* tree, const void* value)
+void* etcpal_rbiter_lower_bound(EtcPalRbIter* self, EtcPalRbTree* tree, const void* value)
 {
   void* result = NULL;
 
@@ -818,7 +818,7 @@ void* etcpal_rbiter_lower_bound(EtcPalRbIter* self, const EtcPalRbTree* tree, co
  * @param[in] value The value to compare against to determine the upper bound.
  * @return Pointer to the upper bound value, or NULL (the end of the tree has been reached).
  */
-void* etcpal_rbiter_upper_bound(EtcPalRbIter* self, const EtcPalRbTree* tree, const void* value)
+void* etcpal_rbiter_upper_bound(EtcPalRbIter* self, EtcPalRbTree* tree, const void* value)
 {
   void* result = NULL;
 

--- a/src/etcpal/rbtree.c
+++ b/src/etcpal/rbtree.c
@@ -181,27 +181,22 @@ EtcPalRbTree* etcpal_rbtree_init(EtcPalRbTree*           self,
  */
 void* etcpal_rbtree_find(EtcPalRbTree* self, const void* value)
 {
-  void* result = NULL;
-  if (self)
-  {
-    EtcPalRbNode* it = self->root;
-    int           cmp = 0;
+  void*        result = NULL;
+  EtcPalRbIter tree_iter;
 
-    while (it)
-    {
-      if ((cmp = self->cmp(self, it->value, value)) != 0)
-      {
-        /* If the tree supports duplicates, they should be chained to the right subtree for this to
-         * work */
-        it = it->link[cmp < 0];
-      }
-      else
-      {
-        break;
-      }
-    }
-    result = it ? it->value : NULL;
+  etcpal_rbiter_init(&tree_iter);
+
+  int cmp = rb_iter_binary_search(&tree_iter, self, value);
+
+  if ((cmp == 0) && (tree_iter.node))
+  {
+    result = tree_iter.node->value;
   }
+  else
+  {
+    result = NULL;
+  }
+
   return result;
 }
 

--- a/tests/unit/live/test_rbtree.c
+++ b/tests/unit/live/test_rbtree.c
@@ -116,6 +116,9 @@ void test_bound(int is_lower_bound)
   // Test bound of ints from 0 to 99 inclusive.
   for (int i = 0; i < INT_ARRAY_SIZE; ++i)
   {
+    char test_error_msg[100];
+    sprintf(test_error_msg, "The %s function failed a test on iteration %d.", function_name_log_str, i);
+
     int expected_value = -1;
 
     if (is_lower_bound)
@@ -136,42 +139,21 @@ void test_bound(int is_lower_bound)
     // Check that this value can be found with etcpal_rbtree_find.
     if (bound)
     {
-      int* found = (int*)etcpal_rbtree_find(&tree, bound);
-
-      char test_null_error_msg[100];
-      sprintf(test_null_error_msg, "The %s function for %d returned %d, which isn't in the red-black tree.",
-              function_name_log_str, i, *bound);
-      TEST_ASSERT_NOT_NULL_MESSAGE(found, test_null_error_msg);
+      TEST_ASSERT_NOT_NULL_MESSAGE(etcpal_rbtree_find(&tree, bound), test_error_msg);
     }
 
     // Check the return value against the expected result.
     if (expected_value >= INT_ARRAY_SIZE)  // Expect NULL.
     {
-      int test_error_value = -1;
-      if (bound)
-      {
-        test_error_value = *bound;
-      }
-
-      char test_not_null_error_msg[100];
-      sprintf(test_not_null_error_msg, "The %s function for %d returned %d, when it should have returned NULL.",
-              function_name_log_str, i, test_error_value);
-
-      TEST_ASSERT_NULL_MESSAGE(bound, test_not_null_error_msg);
+      TEST_ASSERT_NULL_MESSAGE(bound, test_error_msg);
     }
     else  // Expect non-NULL.
     {
-      char test_null_error_msg[100];
-      sprintf(test_null_error_msg, "The %s function for %d returned NULL, when it should have returned %d.",
-              function_name_log_str, i, expected_value);
-      TEST_ASSERT_NOT_NULL_MESSAGE(bound, test_null_error_msg);
+      TEST_ASSERT_NOT_NULL_MESSAGE(bound, test_error_msg);
 
       if (bound)
       {
-        char test_not_equal_error_msg[100];
-        sprintf(test_not_equal_error_msg, "The %s function for %d returned %d, when it should have returned %d.",
-                function_name_log_str, i, *bound, expected_value);
-        TEST_ASSERT_EQUAL_MESSAGE(*bound, expected_value, test_not_equal_error_msg);
+        TEST_ASSERT_EQUAL_MESSAGE(*bound, expected_value, test_error_msg);
       }
     }
 

--- a/tests/unit/live/test_rbtree.c
+++ b/tests/unit/live/test_rbtree.c
@@ -46,7 +46,7 @@ size_t       next_node_index;
 static EtcPalRbNode* get_node();
 static int           int_compare(const EtcPalRbTree* self, const void* value_a, const void* value_b);
 static void          populate_int_arrays();
-static void          initialize_tree_with_random_even_ints(const EtcPalRbTree* self);
+static void          initialize_tree_with_random_even_ints(EtcPalRbTree* self);
 static void          test_bound(int is_lower_bound);
 
 FAKE_VALUE_FUNC(EtcPalRbNode*, node_alloc);
@@ -88,7 +88,7 @@ void populate_int_arrays()
   }
 }
 
-void initialize_tree_with_random_even_ints(const EtcPalRbTree* self)
+void initialize_tree_with_random_even_ints(EtcPalRbTree* self)
 {
   TEST_ASSERT_NOT_NULL(etcpal_rbtree_init(self, int_compare, node_alloc, node_dealloc));
 
@@ -144,6 +144,7 @@ void test_bound(int is_lower_bound)
       TEST_ASSERT_NOT_NULL_MESSAGE(found, test_null_error_msg);
     }
 
+    // Check the return value against the expected result.
     if (expected_value >= INT_ARRAY_SIZE)  // Expect NULL.
     {
       int test_error_value = -1;
@@ -172,6 +173,35 @@ void test_bound(int is_lower_bound)
                 function_name_log_str, i, *bound, expected_value);
         TEST_ASSERT_EQUAL_MESSAGE(*bound, expected_value, test_not_equal_error_msg);
       }
+    }
+
+    // Check the iterator.
+    int* last = NULL;
+    int* val = bound;
+    for (int j = 0; (j < 10) && (val != NULL); ++j, (val = (int*)etcpal_rbiter_prev(&iter)))
+    {
+      TEST_ASSERT_NOT_NULL(iter.tree);
+      TEST_ASSERT_NOT_NULL(iter.node);
+
+      if (val)
+      {
+        TEST_ASSERT_EQUAL(*val % 2, 0);
+
+        if (last)
+        {
+          TEST_ASSERT_EQUAL(*last - *val, 2);
+        }
+      }
+
+      last = val;
+    }
+
+    if (val == NULL)
+    {
+      // Should be the same as when calling rbiter_next at the end, or rbiter_prev at the beginning.
+      TEST_ASSERT_NOT_NULL(iter.tree);
+      TEST_ASSERT_NULL(iter.node);
+      TEST_ASSERT_EQUAL(iter.top, 0);
     }
   }
 

--- a/tests/unit/live/test_rbtree.c
+++ b/tests/unit/live/test_rbtree.c
@@ -133,6 +133,17 @@ void test_bound(int is_lower_bound)
     int* bound = (int*)(is_lower_bound ? etcpal_rbiter_lower_bound(&iter, &tree, &i)
                                        : etcpal_rbiter_upper_bound(&iter, &tree, &i));
 
+    // Check that this value can be found with etcpal_rbtree_find.
+    if (bound)
+    {
+      int* found = (int*)etcpal_rbtree_find(&tree, bound);
+
+      char test_null_error_msg[100];
+      sprintf(test_null_error_msg, "The %s function for %d returned %d, which isn't in the red-black tree.",
+              function_name_log_str, i, *bound);
+      TEST_ASSERT_NOT_NULL_MESSAGE(found, test_null_error_msg);
+    }
+
     if (expected_value >= INT_ARRAY_SIZE)  // Expect NULL.
     {
       int test_error_value = -1;


### PR DESCRIPTION
I wrote the equivalents of std::set::lower_bound and std::set::upper_bound. This will be very useful for the merger implementation. I will be writing unit tests for this tomorrow.