### PR TITLE
Add queue docs, and make some slight API changes

### DIFF
--- a/docs/etcpal.tag
+++ b/docs/etcpal.tag
@@ -88,6 +88,13 @@
     </member>
   </compound>
   <compound kind="file">
+    <name>queue.h</name>
+    <path>E:/git/ETCLabs/EtcPal/include/etcpal/cpp/</path>
+    <filename>cpp_2queue_8h</filename>
+    <includes id="cpp_2common_8h" name="common.h" local="yes" imported="no">etcpal/cpp/common.h</includes>
+    <class kind="class">etcpal::Queue</class>
+  </compound>
+  <compound kind="file">
     <name>thread.h</name>
     <path>E:/git/ETCLabs/EtcPal/include/etcpal/cpp/</path>
     <filename>cpp_2thread_8h</filename>
@@ -2008,6 +2015,67 @@
     </member>
   </compound>
   <compound kind="class">
+    <name>etcpal::Queue</name>
+    <filename>classetcpal_1_1_queue.html</filename>
+    <templarg>T</templarg>
+    <member kind="function">
+      <type></type>
+      <name>Queue</name>
+      <anchorfile>classetcpal_1_1_queue.html</anchorfile>
+      <anchor>ae729f6dede41f22b98b861eac4ac1895</anchor>
+      <arglist>(size_t size)</arglist>
+    </member>
+    <member kind="function">
+      <type></type>
+      <name>~Queue</name>
+      <anchorfile>classetcpal_1_1_queue.html</anchorfile>
+      <anchor>a240bdcfcc136e53aeaac3aa454cc26bf</anchor>
+      <arglist>()</arglist>
+    </member>
+    <member kind="function">
+      <type>bool</type>
+      <name>Send</name>
+      <anchorfile>classetcpal_1_1_queue.html</anchorfile>
+      <anchor>aa5e74f70881c76ee779a05d7c0a0283e</anchor>
+      <arglist>(const T &amp;data, int timeout_ms=0)</arglist>
+    </member>
+    <member kind="function">
+      <type>bool</type>
+      <name>SendFromIsr</name>
+      <anchorfile>classetcpal_1_1_queue.html</anchorfile>
+      <anchor>a4a645b7a56c142bd9b04f703893a5879</anchor>
+      <arglist>(const T &amp;data)</arglist>
+    </member>
+    <member kind="function">
+      <type>bool</type>
+      <name>Receive</name>
+      <anchorfile>classetcpal_1_1_queue.html</anchorfile>
+      <anchor>a1e05b9a1beab8065c28062e2a91d4cf7</anchor>
+      <arglist>(T &amp;data, int timeout_ms=0)</arglist>
+    </member>
+    <member kind="function">
+      <type>bool</type>
+      <name>Receive</name>
+      <anchorfile>classetcpal_1_1_queue.html</anchorfile>
+      <anchor>ad9261100b606a1dc7f096a813987fcfd</anchor>
+      <arglist>(T &amp;data, const std::chrono::duration&lt; Rep, Period &gt; &amp;timeout=std::chrono::milliseconds(0))</arglist>
+    </member>
+    <member kind="function">
+      <type>bool</type>
+      <name>IsEmpty</name>
+      <anchorfile>classetcpal_1_1_queue.html</anchorfile>
+      <anchor>a8e12342fc420701fbffd97025421575a</anchor>
+      <arglist>() const</arglist>
+    </member>
+    <member kind="function">
+      <type>bool</type>
+      <name>IsEmptyFromIsr</name>
+      <anchorfile>classetcpal_1_1_queue.html</anchorfile>
+      <anchor>a9cc49246382de0eeb66f493207fb4dbc</anchor>
+      <arglist>() const</arglist>
+    </member>
+  </compound>
+  <compound kind="class">
     <name>etcpal::ReadGuard</name>
     <filename>classetcpal_1_1_read_guard.html</filename>
     <member kind="function">
@@ -3401,6 +3469,7 @@
     <subgroup>etcpal_thread</subgroup>
     <subgroup>etcpal_timer</subgroup>
     <subgroup>etcpal_lock</subgroup>
+    <subgroup>etcpal_queue</subgroup>
   </compound>
   <compound kind="group">
     <name>etcpal_net</name>
@@ -5698,6 +5767,7 @@
     <subgroup>etcpal_cpp_inet</subgroup>
     <subgroup>etcpal_cpp_lock</subgroup>
     <subgroup>etcpal_cpp_log</subgroup>
+    <subgroup>etcpal_cpp_queue</subgroup>
     <subgroup>etcpal_cpp_thread</subgroup>
     <subgroup>etcpal_cpp_timer</subgroup>
     <subgroup>etcpal_cpp_uuid</subgroup>
@@ -5777,6 +5847,12 @@
       <enumvalue file="group__etcpal__cpp__log.html" anchor="gga886bd6be55942894f6ddb878d1cfc662afd1dd0c603be8170f9eae0be9f2f6afb">Direct</enumvalue>
       <enumvalue file="group__etcpal__cpp__log.html" anchor="gga886bd6be55942894f6ddb878d1cfc662a7b2f31b90fe1c2cc33a52233c1925df3">Queued</enumvalue>
     </member>
+  </compound>
+  <compound kind="group">
+    <name>etcpal_cpp_queue</name>
+    <title>queue (RTOS queues)</title>
+    <filename>group__etcpal__cpp__queue.html</filename>
+    <class kind="class">etcpal::Queue</class>
   </compound>
   <compound kind="group">
     <name>etcpal_cpp_thread</name>
@@ -6118,6 +6194,74 @@
       <anchorfile>group__etcpal__sem.html</anchorfile>
       <anchor>gaa4d8fce64dfa93c4c2f7bd08100ef8b0</anchor>
       <arglist>(etcpal_sem_t *id)</arglist>
+    </member>
+  </compound>
+  <compound kind="group">
+    <name>etcpal_queue</name>
+    <title>queue (RTOS queues)</title>
+    <filename>group__etcpal__queue.html</filename>
+    <member kind="function">
+      <type>bool</type>
+      <name>etcpal_queue_create</name>
+      <anchorfile>group__etcpal__queue.html</anchorfile>
+      <anchor>gaefbd1625abdb0e502024b9c9749c2b17</anchor>
+      <arglist>(etcpal_queue_t *id, size_t size, size_t item_size)</arglist>
+    </member>
+    <member kind="function">
+      <type>void</type>
+      <name>etcpal_queue_destroy</name>
+      <anchorfile>group__etcpal__queue.html</anchorfile>
+      <anchor>ga89749b4899a165bb461570e8a91d470c</anchor>
+      <arglist>(etcpal_queue_t *id)</arglist>
+    </member>
+    <member kind="function">
+      <type>bool</type>
+      <name>etcpal_queue_send</name>
+      <anchorfile>group__etcpal__queue.html</anchorfile>
+      <anchor>gad11692ddc849a8c049c1f15da818957d</anchor>
+      <arglist>(etcpal_queue_t *id, const void *data)</arglist>
+    </member>
+    <member kind="function">
+      <type>bool</type>
+      <name>etcpal_queue_timed_send</name>
+      <anchorfile>group__etcpal__queue.html</anchorfile>
+      <anchor>gae0c1e587408884bfdf7e9502cac7ffa7</anchor>
+      <arglist>(etcpal_queue_t *id, const void *data, int timeout_ms)</arglist>
+    </member>
+    <member kind="function">
+      <type>bool</type>
+      <name>etcpal_queue_send_from_isr</name>
+      <anchorfile>group__etcpal__queue.html</anchorfile>
+      <anchor>ga19c542b25dd6f5884c4d69ec8c891bb2</anchor>
+      <arglist>(etcpal_queue_t *id, const void *data)</arglist>
+    </member>
+    <member kind="function">
+      <type>bool</type>
+      <name>etcpal_queue_receive</name>
+      <anchorfile>group__etcpal__queue.html</anchorfile>
+      <anchor>ga6606a64800aeb535bc2fea3317e6fd44</anchor>
+      <arglist>(etcpal_queue_t *id, void *data)</arglist>
+    </member>
+    <member kind="function">
+      <type>bool</type>
+      <name>etcpal_queue_timed_receive</name>
+      <anchorfile>group__etcpal__queue.html</anchorfile>
+      <anchor>ga13c3c4ca6b7b2ace00da407f52bba261</anchor>
+      <arglist>(etcpal_queue_t *id, void *data, int timeout_ms)</arglist>
+    </member>
+    <member kind="function">
+      <type>bool</type>
+      <name>etcpal_queue_is_empty</name>
+      <anchorfile>group__etcpal__queue.html</anchorfile>
+      <anchor>ga3c0f4a48f832d88fead582a330255aec</anchor>
+      <arglist>(const etcpal_queue_t *id)</arglist>
+    </member>
+    <member kind="function">
+      <type>bool</type>
+      <name>etcpal_queue_is_empty_from_isr</name>
+      <anchorfile>group__etcpal__queue.html</anchorfile>
+      <anchor>ga0a72aed21853d03ac10a09bafd148d0d</anchor>
+      <arglist>(const etcpal_queue_t *id)</arglist>
     </member>
   </compound>
   <compound kind="group">

--- a/include/etcpal/cpp/queue.h
+++ b/include/etcpal/cpp/queue.h
@@ -101,7 +101,7 @@ public:
 
   bool Receive(T& data, int timeout_ms = ETCPAL_WAIT_FOREVER);
   template <class Rep, class Period>
-  bool Receive(T& data, const std::chrono::duration<Rep, Period>& timeout = std::chrono::milliseconds(0));
+  bool Receive(T& data, const std::chrono::duration<Rep, Period>& timeout);
   bool IsEmpty() const;
   bool IsEmptyFromIsr() const;
 

--- a/include/os/freertos/etcpal/os_queue.h
+++ b/include/os/freertos/etcpal/os_queue.h
@@ -21,6 +21,7 @@
 #define ETCPAL_OS_QUEUE_H_
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <FreeRTOS.h>
 #include "etcpal/common.h"
 #include <queue.h>
@@ -30,9 +31,9 @@ extern "C" {
 #endif
 
 typedef QueueHandle_t etcpal_queue_t;
-typedef TickType_t etcpal_ticks_t;
 
 bool etcpal_queue_create(etcpal_queue_t* id, size_t size, size_t item_size);
+void etcpal_queue_destroy(etcpal_queue_t* id);
 
 bool etcpal_queue_send(etcpal_queue_t* id, const void* data);
 bool etcpal_queue_timed_send(etcpal_queue_t* id, const void* data, int timeout_ms);

--- a/src/etcpal/queue.dox
+++ b/src/etcpal/queue.dox
@@ -1,0 +1,174 @@
+Whoa, this isn't a real source file! What's going on here? Well, the headers for this module are
+platform-specific, and some of them implement types and functions differently (i.e. functions as
+macros, etc.), so the documentation needs somewhere to pull a standard interface from. Voila!
+
+/**
+ * @defgroup etcpal_queue queue (RTOS queues)
+ * @ingroup etcpal_os
+ * @brief Platform-neutral blocking RTOS queues.
+ *
+ * ```c
+ * #include "etcpal/queue.h"
+ * ```
+ *
+ * Provides a platform-neutral API to RTOS queue functionality.
+ *
+ * @code
+ * #include "etcpal/queue.h"
+ *
+ * typedef struct Foo
+ * {
+ *   int value;
+ * } Foo;
+ * etcpal_queue_t queue;
+ *
+ * void main_task(void* arg)
+ * {
+ *   etcpal_error_t res = etcpal_queue_create(&queue, 10, sizeof(Foo));
+ *   if (res != kEtcPalErrOk)
+ *   {
+ *     printf("Queue creation failed: '%s'\n", etcpal_strerror(res));
+ *     return;
+ *   }
+ *
+ *   while (true)
+ *   {
+ *     Foo foo;
+ *     // Blocks until a new Foo is retrieved from the queue
+ *     if (etcpal_queue_receive(&queue, &foo))
+ *     {
+ *       printf("Got new Foo with value %d\n", foo.value);
+ *     }
+ *     else
+ *     {
+ *       printf("Error receiving from queue.\n");
+ *     }
+ *   }
+ *
+ *   etcpal_queue_destroy(&queue);
+ * }
+ *
+ * // Send a new Foo to the queue when an interrupt comes in.
+ * void interrupt_handler(void)
+ * {
+ *   Foo foo;
+ *   foo.value = REG_READ();
+ *   etcpal_queue_send_from_isr(&queue, &foo);
+ * }
+ * @endcode
+ *
+ * There are also functions for sending and receiving with a timeout, and for checking to see if
+ * the queue is empty.
+ *
+ * Queues are only available on RTOS platforms. The current availability is as follows:
+ *
+ * | Platform | Queue Functions Available |
+ * |----------|---------------------------|
+ * | FreeRTOS | Yes                       |
+ * | Linux    | No                        |
+ * | macOS    | No                        |
+ * | MQX      | No                        |
+ * | Windows  | No                        |
+ *
+ * @{
+ */
+
+/**
+ * @brief Create a new queue.
+ * @param[out] id Queue identifier on which to create a queue. If this function returns true, id
+                  becomes valid for calls to other etcpal_queue API functions.
+ * @param[in] size The maximum number of items that can be held in the queue.
+ * @param[in] item_size The size in bytes of the item type to be held in the queue.
+ * @return true: The queue was created.
+ * @return false: The queue was not created.
+ */
+bool etcpal_queue_create(etcpal_queue_t* id, size_t size, size_t item_size);
+
+/**
+ * @brief Destroy a queue.
+ * @details Frees the queue's resources back to the operating system.
+ * @param[in] id Identifier for the queue to destroy.
+ */
+void etcpal_queue_destroy(etcpal_queue_t* id);
+
+/**
+ * @brief Add an item to a queue.
+ * @details Blocks until there is room in the queue to add a new item.
+ * @param[in] id Identifier for the queue to which to add an item.
+ * @param[in] data Pointer to item to add to the queue.
+ * @return true: Item added successfully.
+ * @return false: An error occurred while trying to add an item to the queue.
+ */
+bool etcpal_queue_send(etcpal_queue_t* id, const void* data);
+
+/**
+ * @brief Add an item to a queue, giving up after a timeout.
+ * @param[in] id Identifier for the queue to which to add an item.
+ * @param[in] data Pointer to item to add to the queue.
+ * @param[in] timeout_ms Maximum amount of time to wait for space to be available, in milliseconds.
+ *                       If #ETCPAL_WAIT_FOREVER is given, the result is the same as if
+ *                       etcpal_queue_send() was called.
+ * @return true: Item added successfully.
+ * @return false: Timeout or error occurred while trying to add an item to the queue.
+ */
+bool etcpal_queue_timed_send(etcpal_queue_t* id, const void* data, int timeout_ms);
+
+/**
+ * @brief Add an item to a queue from an interrupt context.
+ *
+ * This function is meaningful on platforms which have a different method for interacting with
+ * queues from an interrupt context. This function never blocks, i.e. the behavior is similar to
+ * calling etcpal_queue_timed_send() with a value of 0 for the timeout_ms parameter.
+ *
+ * @param[in] id Identifier for the queue to which to add an item.
+ * @param[in] data Pointer to item to add to the queue.
+ * @return true: Item added successfully.
+ * @return false: Timeout or error occurred while trying to add an item to the queue.
+ */
+bool etcpal_queue_send_from_isr(etcpal_queue_t* id, const void* data);
+
+/**
+ * @brief Retrieve the first item from a queue.
+ * @details Blocks until there is an item available to retrieve from the queue.
+ * @param[in] id Identifier for the queue from which to retrieve an item.
+ * @param[out] data Pointer to a location to write the object's data.
+ * @return true: Item retrieved successfully.
+ * @return false: Error occurred while trying to retrieve an item from the queue.
+ */
+bool etcpal_queue_receive(etcpal_queue_t* id, void* data);
+
+/**
+ * @brief Retrieve the first item from a queue, giving up after a timeout.
+ * @param[in] id Identifier for the queue from which to retrieve an item.
+ * @param[out] data Pointer to a location to write the object's data.
+ * @param[in] timeout_ms Maximum amount of time to wait for an item to be available, in
+ *                       milliseconds. If #ETCPAL_WAIT_FOREVER is given, the result is the same as
+ *                       if etcpal_queue_receive() was called.
+ * @return true: Item retrieved successfully.
+ * @return false: Timeout or error occurred while trying to retrieve an item from the queue.
+ */
+bool etcpal_queue_timed_receive(etcpal_queue_t* id, void* data, int timeout_ms);
+
+/**
+ * @brief Determine whether a queue is currently empty.
+ * @param[in] id Identifier for the queue to check the status of.
+ * @return true: The queue is empty.
+ * @return false: The queue is not empty.
+ */
+bool etcpal_queue_is_empty(const etcpal_queue_t* id);
+
+/**
+ * @brief Determine whether a queue is currently empty from an interrupt context.
+ *
+ * This function is meaningful on platforms which have a different method for interacting with
+ * queues from an interrupt context.
+ *
+ * @param[in] id Identifier for the queue to check the status of.
+ * @return true: The queue is empty.
+ * @return false: The queue is not empty.
+ */
+bool etcpal_queue_is_empty_from_isr(const etcpal_queue_t* id);
+
+/*!
+ * @}
+ */

--- a/src/os/freertos/etcpal/os_queue.c
+++ b/src/os/freertos/etcpal/os_queue.c
@@ -30,6 +30,14 @@ bool etcpal_queue_create(etcpal_queue_t* id, size_t size, size_t item_size)
   return false;
 }
 
+void etcpal_queue_destroy(etcpal_queue_t* id)
+{
+  if (id)
+  {
+    vQueueDelete(*id);
+  }
+}
+
 bool etcpal_queue_send(etcpal_queue_t* id, const void* data)
 {
   if (id)
@@ -85,7 +93,6 @@ bool etcpal_queue_timed_receive(etcpal_queue_t* id, void* data, int timeout_ms)
 
 bool etcpal_queue_is_empty(const etcpal_queue_t* id)
 {
-
   UBaseType_t numMessages = uxQueueMessagesWaiting(*id);
 
   return (numMessages == 0);

--- a/tests/unit/cpp/test_queue.cpp
+++ b/tests/unit/cpp/test_queue.cpp
@@ -19,7 +19,6 @@
 
 #include "etcpal/cpp/queue.h"
 
-#include <chrono>
 #include "unity_fixture.h"
 
 extern "C" {

--- a/tests/unit/cpp/test_queue.cpp
+++ b/tests/unit/cpp/test_queue.cpp
@@ -19,6 +19,7 @@
 
 #include "etcpal/cpp/queue.h"
 
+#include <chrono>
 #include "unity_fixture.h"
 
 extern "C" {
@@ -35,17 +36,17 @@ TEST_TEAR_DOWN(etcpal_cpp_queue)
 
 TEST(etcpal_cpp_queue, check_empty)
 {
-    etcpal::Queue<char> q(5);
-    TEST_ASSERT_TRUE(q.IsEmpty());
+  etcpal::Queue<char> q(5);
+  TEST_ASSERT_TRUE(q.IsEmpty());
 }
 
 TEST(etcpal_cpp_queue, can_send_and_receive)
 {
   etcpal::Queue<char> q(3);
-  char data = 0xDE;
-  TEST_ASSERT_TRUE(q.SendToQueue(data));
-  char receivedData;
-  TEST_ASSERT_TRUE(q.ReceiveFromQueue(receivedData, 0));
+  char                data = 0xDE;
+  TEST_ASSERT_TRUE(q.Send(data));
+  char receivedData = 0;
+  TEST_ASSERT_TRUE(q.Receive(receivedData));
   TEST_ASSERT_EQUAL(data, receivedData);
 }
 
@@ -53,30 +54,28 @@ TEST(etcpal_cpp_queue, will_timeout_on_send)
 {
   // Create queue for 3 chars
   etcpal::Queue<char> q(3);
-  char data = 0xDE;
-  TEST_ASSERT_TRUE(q.SendToQueue(data, false, 0));
+  char                data = 0xDE;
+  TEST_ASSERT_TRUE(q.Send(data));
   data = 0xAD;
-  TEST_ASSERT_TRUE(q.SendToQueue(data, false, 0));
+  TEST_ASSERT_TRUE(q.Send(data));
   data = 0xBE;
-  TEST_ASSERT_TRUE(q.SendToQueue(data, false, 0));
+  TEST_ASSERT_TRUE(q.Send(data));
 
   // This one should NOT work because we are over our size
   data = 0xEF;
-  TEST_ASSERT_FALSE(q.SendToQueue(data, false, 0));
+  TEST_ASSERT_FALSE(q.Send(data));
 }
 
 TEST(etcpal_cpp_queue, will_timeout_on_receive)
 {
-  etcpal_queue_t queue;
-
   // Create queue for 3 chars
   etcpal::Queue<char> q(3);
-  char data = 0xDE;
-  TEST_ASSERT_TRUE(q.SendToQueue(data, false, 0));
+  char                data = 0xDE;
+  TEST_ASSERT_TRUE(q.Send(data));
   data = 0xAD;
   char receivedData = 0x00;
-  TEST_ASSERT_TRUE(q.ReceiveFromQueue(receivedData, 10));
-  TEST_ASSERT_FALSE(q.ReceiveFromQueue(receivedData, 10));
+  TEST_ASSERT_TRUE(q.Receive(receivedData, 10));
+  TEST_ASSERT_FALSE(q.Receive(receivedData, 10));
 }
 
 TEST(etcpal_cpp_queue, can_detect_empty)
@@ -86,14 +85,14 @@ TEST(etcpal_cpp_queue, can_detect_empty)
   TEST_ASSERT_TRUE(q.IsEmpty());
 
   char data = 0xDE;
-  TEST_ASSERT_TRUE(q.SendToQueue(data, false, 0));
+  TEST_ASSERT_TRUE(q.Send(data));
   TEST_ASSERT_FALSE(q.IsEmpty());
 
   char receivedData = 0x00;
-  TEST_ASSERT_TRUE(q.ReceiveFromQueue(receivedData, 0));
+  TEST_ASSERT_TRUE(q.Receive(receivedData));
   TEST_ASSERT_TRUE(q.IsEmpty());
 
-  TEST_ASSERT_TRUE(q.SendToQueue(data, false, 0));
+  TEST_ASSERT_TRUE(q.Send(data));
   TEST_ASSERT_FALSE(q.IsEmpty());
 }
 

--- a/tests/unit/cpp/test_queue.cpp
+++ b/tests/unit/cpp/test_queue.cpp
@@ -62,7 +62,7 @@ TEST(etcpal_cpp_queue, will_timeout_on_send)
 
   // This one should NOT work because we are over our size
   data = 0xEF;
-  TEST_ASSERT_FALSE(q.Send(data));
+  TEST_ASSERT_FALSE(q.Send(data, 10));
 }
 
 TEST(etcpal_cpp_queue, will_timeout_on_receive)

--- a/tests/unit/live/test_queue.c
+++ b/tests/unit/live/test_queue.c
@@ -42,6 +42,7 @@ TEST(etcpal_queue, can_send_and_receive)
   char receivedData;
   TEST_ASSERT_TRUE(etcpal_queue_receive(&queue, &receivedData));
   TEST_ASSERT_EQUAL(data, receivedData);
+  etcpal_queue_destroy(&queue);
 }
 
 TEST(etcpal_queue, will_timeout_on_send)
@@ -60,6 +61,8 @@ TEST(etcpal_queue, will_timeout_on_send)
   // This one should NOT work because we are over our size
   data = 0xEF;
   TEST_ASSERT_FALSE(etcpal_queue_timed_send(&queue, &data, 10));
+
+  etcpal_queue_destroy(&queue);
 }
 
 TEST(etcpal_queue, will_timeout_on_receive)
@@ -73,6 +76,8 @@ TEST(etcpal_queue, will_timeout_on_receive)
   char receivedData = 0x00;
   TEST_ASSERT_TRUE(etcpal_queue_timed_receive(&queue, &receivedData, 10));
   TEST_ASSERT_FALSE(etcpal_queue_timed_receive(&queue, &receivedData, 10));
+
+  etcpal_queue_destroy(&queue);
 }
 
 TEST(etcpal_queue, can_detect_empty)
@@ -93,6 +98,8 @@ TEST(etcpal_queue, can_detect_empty)
 
   TEST_ASSERT_TRUE(etcpal_queue_timed_send(&queue, &data, 0));
   TEST_ASSERT_FALSE(etcpal_queue_is_empty(&queue));
+
+  etcpal_queue_destroy(&queue);
 }
 
 TEST_GROUP_RUNNER(etcpal_queue)


### PR DESCRIPTION
* Add docs to all queue functions
* Shorten Queue class functions to essential verbs Send() and Receive()
* Allow the Receive() function to take an arbitrary chrono::duration
* Change Send() and Receive() to block by default
* Add etcpal_queue_destroy() function