### PR TITLE
ETCPAL-84 Fix buggy wraparound behavior in etcpal_getms() on FreeRTOS

### DIFF
--- a/src/os/freertos/etcpal/os_timer.c
+++ b/src/os/freertos/etcpal/os_timer.c
@@ -38,7 +38,7 @@ void etcpal_timer_deinit(void)
 
 uint32_t etcpal_getms(void)
 {
-  return (uint32_t)(xTaskGetTickCount() * 1000 / configTICK_RATE_HZ);
+  return (uint32_t)(((uint64_t)xTaskGetTickCount()) * 1000 / configTICK_RATE_HZ);
 }
 
 #endif  // !defined(ETCPAL_BUILDING_MOCK_LIB)


### PR DESCRIPTION
The previous implementation had buggy behavior that caused etcpal_getms() to wrap from (UINT32_MAX / 1000) back to 0 instead of UINT32_MAX back to 0 as expected.

After the fix, that buggy behavior still exists, but only happens approximately once every 584,000 years. Hopefully this is acceptable 😉 