### PR TITLE
ETCPAL-61: New module etcpal/cpp/opaque_id.h

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   * `etcpal_thread_os_handle_t`
   * etcpal_thread_get_os_handle()
   * etcpal_thread_get_current_os_handle()
+- New C++ feature: Strongly typed opaque IDs (`etcpal/cpp/opaque_id.h`)
 
 ### Changed
 - Separated etcpal/lock.h into more specific headers: etcpal/mutex.h, etcpal/signal.h, etcpal/sem.h

--- a/docs/etcpal.tag
+++ b/docs/etcpal.tag
@@ -2,7 +2,7 @@
 <tagfile>
   <compound kind="file">
     <name>common.h</name>
-    <path>E:/github/ETCLabs/EtcPal/include/etcpal/cpp/</path>
+    <path>D:/github/ETCLabs/EtcPal/include/etcpal/cpp/</path>
     <filename>cpp_2common_8h</filename>
     <member kind="define">
       <type>#define</type>
@@ -27,8 +27,14 @@
     </member>
   </compound>
   <compound kind="file">
+    <name>opaque_id.h</name>
+    <path>D:/github/ETCLabs/EtcPal/include/etcpal/cpp/</path>
+    <filename>opaque__id_8h</filename>
+    <class kind="class">etcpal::OpaqueId</class>
+  </compound>
+  <compound kind="file">
     <name>error.h</name>
-    <path>E:/github/ETCLabs/EtcPal/include/etcpal/cpp/</path>
+    <path>D:/github/ETCLabs/EtcPal/include/etcpal/cpp/</path>
     <filename>cpp_2error_8h</filename>
     <includes id="cpp_2common_8h" name="common.h" local="yes" imported="no">etcpal/cpp/common.h</includes>
     <class kind="class">etcpal::Error</class>
@@ -37,7 +43,7 @@
   </compound>
   <compound kind="file">
     <name>event_group.h</name>
-    <path>E:/github/ETCLabs/EtcPal/include/etcpal/cpp/</path>
+    <path>D:/github/ETCLabs/EtcPal/include/etcpal/cpp/</path>
     <filename>cpp_2event__group_8h</filename>
     <includes id="cpp_2common_8h" name="common.h" local="yes" imported="no">etcpal/cpp/common.h</includes>
     <class kind="class">etcpal::EventGroup</class>
@@ -51,7 +57,7 @@
   </compound>
   <compound kind="file">
     <name>inet.h</name>
-    <path>E:/github/ETCLabs/EtcPal/include/etcpal/cpp/</path>
+    <path>D:/github/ETCLabs/EtcPal/include/etcpal/cpp/</path>
     <filename>cpp_2inet_8h</filename>
     <includes id="cpp_2common_8h" name="common.h" local="yes" imported="no">etcpal/cpp/common.h</includes>
     <class kind="class">etcpal::IpAddr</class>
@@ -70,7 +76,7 @@
   </compound>
   <compound kind="file">
     <name>log.h</name>
-    <path>E:/github/ETCLabs/EtcPal/include/etcpal/cpp/</path>
+    <path>D:/github/ETCLabs/EtcPal/include/etcpal/cpp/</path>
     <filename>cpp_2log_8h</filename>
     <includes id="cpp_2common_8h" name="common.h" local="yes" imported="no">etcpal/cpp/common.h</includes>
     <includes id="cpp_2mutex_8h" name="mutex.h" local="yes" imported="no">etcpal/cpp/mutex.h</includes>
@@ -91,7 +97,7 @@
   </compound>
   <compound kind="file">
     <name>mutex.h</name>
-    <path>E:/github/ETCLabs/EtcPal/include/etcpal/cpp/</path>
+    <path>D:/github/ETCLabs/EtcPal/include/etcpal/cpp/</path>
     <filename>cpp_2mutex_8h</filename>
     <includes id="cpp_2common_8h" name="common.h" local="yes" imported="no">etcpal/cpp/common.h</includes>
     <class kind="class">etcpal::Mutex</class>
@@ -99,14 +105,14 @@
   </compound>
   <compound kind="file">
     <name>queue.h</name>
-    <path>E:/github/ETCLabs/EtcPal/include/etcpal/cpp/</path>
+    <path>D:/github/ETCLabs/EtcPal/include/etcpal/cpp/</path>
     <filename>cpp_2queue_8h</filename>
     <includes id="cpp_2common_8h" name="common.h" local="yes" imported="no">etcpal/cpp/common.h</includes>
     <class kind="class">etcpal::Queue</class>
   </compound>
   <compound kind="file">
     <name>recursive_mutex.h</name>
-    <path>E:/github/ETCLabs/EtcPal/include/etcpal/cpp/</path>
+    <path>D:/github/ETCLabs/EtcPal/include/etcpal/cpp/</path>
     <filename>cpp_2recursive__mutex_8h</filename>
     <includes id="cpp_2common_8h" name="common.h" local="yes" imported="no">etcpal/cpp/common.h</includes>
     <class kind="class">etcpal::RecursiveMutex</class>
@@ -114,7 +120,7 @@
   </compound>
   <compound kind="file">
     <name>rwlock.h</name>
-    <path>E:/github/ETCLabs/EtcPal/include/etcpal/cpp/</path>
+    <path>D:/github/ETCLabs/EtcPal/include/etcpal/cpp/</path>
     <filename>cpp_2rwlock_8h</filename>
     <includes id="cpp_2common_8h" name="common.h" local="yes" imported="no">etcpal/cpp/common.h</includes>
     <class kind="class">etcpal::RwLock</class>
@@ -123,21 +129,21 @@
   </compound>
   <compound kind="file">
     <name>sem.h</name>
-    <path>E:/github/ETCLabs/EtcPal/include/etcpal/cpp/</path>
+    <path>D:/github/ETCLabs/EtcPal/include/etcpal/cpp/</path>
     <filename>cpp_2sem_8h</filename>
     <includes id="cpp_2common_8h" name="common.h" local="yes" imported="no">etcpal/cpp/common.h</includes>
     <class kind="class">etcpal::Semaphore</class>
   </compound>
   <compound kind="file">
     <name>signal.h</name>
-    <path>E:/github/ETCLabs/EtcPal/include/etcpal/cpp/</path>
+    <path>D:/github/ETCLabs/EtcPal/include/etcpal/cpp/</path>
     <filename>cpp_2signal_8h</filename>
     <includes id="cpp_2common_8h" name="common.h" local="yes" imported="no">etcpal/cpp/common.h</includes>
     <class kind="class">etcpal::Signal</class>
   </compound>
   <compound kind="file">
     <name>thread.h</name>
-    <path>E:/github/ETCLabs/EtcPal/include/etcpal/cpp/</path>
+    <path>D:/github/ETCLabs/EtcPal/include/etcpal/cpp/</path>
     <filename>cpp_2thread_8h</filename>
     <includes id="cpp_2common_8h" name="common.h" local="yes" imported="no">etcpal/cpp/common.h</includes>
     <includes id="cpp_2error_8h" name="error.h" local="yes" imported="no">etcpal/cpp/error.h</includes>
@@ -145,7 +151,7 @@
   </compound>
   <compound kind="file">
     <name>timer.h</name>
-    <path>E:/github/ETCLabs/EtcPal/include/etcpal/cpp/</path>
+    <path>D:/github/ETCLabs/EtcPal/include/etcpal/cpp/</path>
     <filename>cpp_2timer_8h</filename>
     <includes id="cpp_2common_8h" name="common.h" local="yes" imported="no">etcpal/cpp/common.h</includes>
     <class kind="class">etcpal::TimePoint</class>
@@ -153,7 +159,7 @@
   </compound>
   <compound kind="file">
     <name>uuid.h</name>
-    <path>E:/github/ETCLabs/EtcPal/include/etcpal/cpp/</path>
+    <path>D:/github/ETCLabs/EtcPal/include/etcpal/cpp/</path>
     <filename>cpp_2uuid_8h</filename>
     <class kind="class">etcpal::Uuid</class>
     <member kind="enumeration">
@@ -172,7 +178,7 @@
   </compound>
   <compound kind="file">
     <name>version.h</name>
-    <path>E:/github/ETCLabs/EtcPal/include/etcpal/</path>
+    <path>D:/github/ETCLabs/EtcPal/include/etcpal/</path>
     <filename>version_8h</filename>
   </compound>
   <compound kind="struct">
@@ -2155,6 +2161,69 @@
     </member>
   </compound>
   <compound kind="class">
+    <name>etcpal::OpaqueId</name>
+    <filename>classetcpal_1_1_opaque_id.html</filename>
+    <templarg>IdType</templarg>
+    <templarg>ValueType</templarg>
+    <templarg>InvalidValue</templarg>
+    <member kind="function">
+      <type>constexpr</type>
+      <name>OpaqueId</name>
+      <anchorfile>classetcpal_1_1_opaque_id.html</anchorfile>
+      <anchor>a5e3f60e8b9cdbd532ae091c2a603ac3b</anchor>
+      <arglist>(ValueType value)</arglist>
+    </member>
+    <member kind="function">
+      <type>constexpr ValueType</type>
+      <name>value</name>
+      <anchorfile>classetcpal_1_1_opaque_id.html</anchorfile>
+      <anchor>afbeb3ea2eee6f9695aa8328ce7d9bac4</anchor>
+      <arglist>() const</arglist>
+    </member>
+    <member kind="function">
+      <type>constexpr bool</type>
+      <name>IsValid</name>
+      <anchorfile>classetcpal_1_1_opaque_id.html</anchorfile>
+      <anchor>ab0b02c2ae96656027facd95c8015b7db</anchor>
+      <arglist>() const</arglist>
+    </member>
+    <member kind="function">
+      <type>constexpr</type>
+      <name>operator bool</name>
+      <anchorfile>classetcpal_1_1_opaque_id.html</anchorfile>
+      <anchor>ad0ed9dded3dc4405713f0b9270930a92</anchor>
+      <arglist>() const</arglist>
+    </member>
+    <member kind="function">
+      <type>constexpr bool</type>
+      <name>operator!</name>
+      <anchorfile>classetcpal_1_1_opaque_id.html</anchorfile>
+      <anchor>ac252a44c73ef696bf047b7b7b0ea13bc</anchor>
+      <arglist>() const</arglist>
+    </member>
+    <member kind="function">
+      <type>constexpr void</type>
+      <name>SetValue</name>
+      <anchorfile>classetcpal_1_1_opaque_id.html</anchorfile>
+      <anchor>ab4b7ca5d45556532c8f244a779504a8b</anchor>
+      <arglist>(const ValueType &amp;newValue)</arglist>
+    </member>
+    <member kind="function">
+      <type>constexpr void</type>
+      <name>Clear</name>
+      <anchorfile>classetcpal_1_1_opaque_id.html</anchorfile>
+      <anchor>adc79a2829b7e197f61e821a2b0942b81</anchor>
+      <arglist>()</arglist>
+    </member>
+    <member kind="function" static="yes">
+      <type>static constexpr OpaqueId</type>
+      <name>Invalid</name>
+      <anchorfile>classetcpal_1_1_opaque_id.html</anchorfile>
+      <anchor>a67fba554b339bd96ec627d8ddebb2794</anchor>
+      <arglist>()</arglist>
+    </member>
+  </compound>
+  <compound kind="class">
     <name>etcpal::Queue</name>
     <filename>classetcpal_1_1_queue.html</filename>
     <templarg>T</templarg>
@@ -2821,6 +2890,13 @@
       <arglist>() const noexcept</arglist>
     </member>
     <member kind="function">
+      <type>etcpal_thread_os_handle_t</type>
+      <name>os_handle</name>
+      <anchorfile>classetcpal_1_1_thread.html</anchorfile>
+      <anchor>a1f9139cb02adad1237dcc17c5cbb7fec</anchor>
+      <arglist>() const noexcept</arglist>
+    </member>
+    <member kind="function">
       <type>Thread &amp;</type>
       <name>SetPriority</name>
       <anchorfile>classetcpal_1_1_thread.html</anchorfile>
@@ -2902,6 +2978,13 @@
       <name>params</name>
       <anchorfile>classetcpal_1_1_thread.html</anchorfile>
       <anchor>aa66aa5c50746cd41312f22bebbf0d4e0</anchor>
+      <arglist>() const noexcept</arglist>
+    </member>
+    <member kind="function">
+      <type>etcpal_thread_os_handle_t</type>
+      <name>os_handle</name>
+      <anchorfile>classetcpal_1_1_thread.html</anchorfile>
+      <anchor>a1f9139cb02adad1237dcc17c5cbb7fec</anchor>
       <arglist>() const noexcept</arglist>
     </member>
     <member kind="function">
@@ -5783,6 +5866,13 @@
     </member>
     <member kind="define">
       <type>#define</type>
+      <name>ETCPAL_THREAD_OS_HANDLE_INVALID</name>
+      <anchorfile>group__etcpal__thread.html</anchorfile>
+      <anchor>ga72620094cf45f5335fc4f9c338b17207</anchor>
+      <arglist></arglist>
+    </member>
+    <member kind="define">
+      <type>#define</type>
       <name>ETCPAL_THREAD_HAS_TIMED_JOIN</name>
       <anchorfile>group__etcpal__thread.html</anchorfile>
       <anchor>gaf382d29335eeeb4ed5c8d295bb8a380b</anchor>
@@ -5800,6 +5890,13 @@
       <name>etcpal_thread_t</name>
       <anchorfile>group__etcpal__thread.html</anchorfile>
       <anchor>ga6ea2bb55f405380e3ea296e3b6164ae8</anchor>
+      <arglist></arglist>
+    </member>
+    <member kind="typedef">
+      <type>PLATFORM_DEFINED</type>
+      <name>etcpal_thread_os_handle_t</name>
+      <anchorfile>group__etcpal__thread.html</anchorfile>
+      <anchor>gad25eb672dee4e360d79cf5988d0b6071</anchor>
       <arglist></arglist>
     </member>
     <member kind="function">
@@ -5831,11 +5928,25 @@
       <arglist>(etcpal_thread_t *id)</arglist>
     </member>
     <member kind="function">
+      <type>etcpal_thread_os_handle_t</type>
+      <name>etcpal_thread_get_os_handle</name>
+      <anchorfile>group__etcpal__thread.html</anchorfile>
+      <anchor>gaf6711b2ff2eee44104ec5f472b2701b1</anchor>
+      <arglist>(etcpal_thread_t *id)</arglist>
+    </member>
+    <member kind="function">
       <type>void</type>
       <name>etcpal_thread_sleep</name>
       <anchorfile>group__etcpal__thread.html</anchorfile>
       <anchor>gaf5d7c5aec312d172e617fd653ade3b08</anchor>
       <arglist>(unsigned int sleep_ms)</arglist>
+    </member>
+    <member kind="function">
+      <type>etcpal_thread_os_handle_t</type>
+      <name>etcpal_thread_get_current_os_handle</name>
+      <anchorfile>group__etcpal__thread.html</anchorfile>
+      <anchor>gae66dc24d979de981d2e2a0475d320be2</anchor>
+      <arglist>(void)</arglist>
     </member>
   </compound>
   <compound kind="group">
@@ -6020,6 +6131,7 @@
     <subgroup>etcpal_cpp_inet</subgroup>
     <subgroup>etcpal_cpp_log</subgroup>
     <subgroup>etcpal_cpp_mutex</subgroup>
+    <subgroup>etcpal_cpp_opaque_id</subgroup>
     <subgroup>etcpal_cpp_queue</subgroup>
     <subgroup>etcpal_cpp_recursive_mutex</subgroup>
     <subgroup>etcpal_cpp_rwlock</subgroup>
@@ -6105,6 +6217,12 @@
     <filename>group__etcpal__cpp__mutex.html</filename>
     <class kind="class">etcpal::Mutex</class>
     <class kind="class">etcpal::MutexGuard</class>
+  </compound>
+  <compound kind="group">
+    <name>etcpal_cpp_opaque_id</name>
+    <title>opaque_id (Strongly typed handles)</title>
+    <filename>group__etcpal__cpp__opaque__id.html</filename>
+    <class kind="class">etcpal::OpaqueId</class>
   </compound>
   <compound kind="group">
     <name>etcpal_cpp_queue</name>

--- a/include/etcpal/cpp/opaque_id.h
+++ b/include/etcpal/cpp/opaque_id.h
@@ -230,40 +230,28 @@ constexpr bool operator!=(const OpaqueId<IdType, ValueType, InvalidValue>& a,
   return !(a == b);
 }
 
-template <class IdType, class ValueType, ValueType InvalidValue>
-constexpr bool operator<(const OpaqueId<IdType, ValueType, InvalidValue>& a,
-                         const OpaqueId<IdType, ValueType, InvalidValue>& b)
-{
-  return a.value() < b.value();
-}
-
-template <class IdType, class ValueType, ValueType InvalidValue>
-constexpr bool operator>(const OpaqueId<IdType, ValueType, InvalidValue>& a,
-                         const OpaqueId<IdType, ValueType, InvalidValue>& b)
-{
-  return b < a;
-}
-
-template <class IdType, class ValueType, ValueType InvalidValue>
-constexpr bool operator<=(const OpaqueId<IdType, ValueType, InvalidValue>& a,
-                          const OpaqueId<IdType, ValueType, InvalidValue>& b)
-{
-  return !(b < a);
-}
-
-template <class IdType, class ValueType, ValueType InvalidValue>
-constexpr bool operator>=(const OpaqueId<IdType, ValueType, InvalidValue>& a,
-                          const OpaqueId<IdType, ValueType, InvalidValue>& b)
-{
-  return !(a < b);
-}
-
 /// @}
 /// @}
 
 };  // namespace etcpal
 
-/// @cond std::hash specialization
+/// @cond std namespace specializations
+
+namespace std
+{
+// Inject a std::less specialization for any template specialization for OpaqueId. This takes the
+// place of operator< for the purposes of OpaqueId usage in ordered containers. We don't provide
+// relational operators other than == and != to avoid the temptation to treat OpaqueIds like
+// numbers.
+template <class IdType, class ValueType, ValueType InvalidValue>
+struct less<etcpal::OpaqueId<IdType, ValueType, InvalidValue>>
+{
+  ETCPAL_CONSTEXPR_14 bool operator()(const etcpal::OpaqueId<IdType, ValueType, InvalidValue>& a,
+                                      const etcpal::OpaqueId<IdType, ValueType, InvalidValue>& b) const
+  {
+    return a.value() < b.value();
+  }
+};
 
 // Inject a new std::hash specialization for any template specialization of OpaqueId, so that
 // OpaqueIds can be used in hash-based containers (e.g. unordered_map and unordered_set) without
@@ -272,8 +260,6 @@ constexpr bool operator>=(const OpaqueId<IdType, ValueType, InvalidValue>& a,
 // The std::hash specialization simply passes through to a hash of the underlying value. If the
 // underlying value is not hashable, this specialization should simply be eliminated without a
 // compile error through SFINAE.
-namespace std
-{
 template <class IdType, class ValueType, ValueType InvalidValue>
 struct hash<etcpal::OpaqueId<IdType, ValueType, InvalidValue>>
 {

--- a/include/etcpal/cpp/opaque_id.h
+++ b/include/etcpal/cpp/opaque_id.h
@@ -1,0 +1,288 @@
+/******************************************************************************
+ * Copyright 2021 ETC Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************
+ * This file is a part of EtcPal. For more information, go to:
+ * https://github.com/ETCLabs/EtcPal
+ ******************************************************************************/
+
+/// @file etcpal/cpp/opaque_id.h
+/// @brief Provides the OpaqueId template type and function definitions.
+
+#ifndef ETCPAL_CPP_OPAQUE_ID_H_
+#define ETCPAL_CPP_OPAQUE_ID_H_
+
+#include <functional>
+
+namespace etcpal
+{
+/// @defgroup etcpal_cpp_opaque_id opaque_id (Strongly typed handles)
+/// @ingroup etcpal_cpp
+/// @brief Provides the OpaqueId type, a type-safe identifier or handle value.
+
+/// @ingroup etcpal_cpp_opaque_id
+/// @brief A strongly-typed ID with arbitrary internal representation.
+///
+/// A typical coding pattern uses handles to represent resources stored elsewhere by a module. The
+/// handles are usually some integer type, given another name by a type definition, e.g.:
+///
+/// @code
+/// using FooHandle = int;
+///
+/// Foo GetFoo(FooHandle handle);
+/// @endcode
+///
+/// Unfortunately, this is not as type-safe as it could be. One would expect that handles cannot be
+/// mixed with other integers or magic numbers:
+///
+/// @code
+/// int regular_ol_number = 12;
+/// GetFoo(regular_ol_number);
+/// GetFoo(42);
+/// @endcode
+///
+/// Although handles are typically meant to be treated as opaque (and thus should not be mixable
+/// with regular numbers), the block above will compile without warnings.
+///
+/// This can be avoided using the OpaqueId class. Usage is as follows:
+/// @code
+/// struct FooHandleType {};
+/// using FooHandle = etcpal::OpaqueId<FooHandleType, int, -1>;
+///
+/// Foo GetFoo(FooHandle handle);
+///
+/// int regular_ol_number = 12;
+/// GetFoo(regular_ol_number); // Error
+/// GetFoo(42); // Error
+/// GetFoo(FooHandle(42)); // No error
+///
+/// FooHandle foo_handle(42);
+/// if (foo_handle == 42) // Error
+/// {
+///   // ...
+/// }
+///
+/// if (foo_handle.value() == 42) // No error
+/// {
+///   // ...
+/// }
+///
+/// struct BarHandleType {};
+/// using BarHandle = etcpal::OpaqueId<BarHandleType, int, -1>;
+///
+/// BarHandle bar_handle(42);
+/// if (bar_handle == foo_handle) // Error
+/// {
+///   // ...
+/// }
+/// @endcode
+///
+/// When using the OpaqueId type, errors from mixing numbers with opaque handles are avoided. Each
+/// distinct specialization of an OpaqueId requires a new struct or class to be defined. This
+/// struct/class is typically empty and its only use is to serve as a distinct type such that
+/// OpaqueIds used for different purposes cannot be mixed with each other.
+///
+/// The underlying type for an OpaqueId follows the template rules for a
+/// [non-type template parameter](https://en.cppreference.com/w/cpp/language/template_parameters),
+/// since an "invalid" value must be passed as a template parameter when specializing OpaqueId.
+/// This means that in pre-C++20 environments, the underlying type can pretty much only be an
+/// integral or enumeration type. In practice, it is almost always an integer type.
+///
+/// OpaqueIds also have the concept of an invalid value, which is what a default-constructed
+/// OpaqueId contains.
+///
+/// @code
+/// FooHandle handle;
+/// if (!handle) // Evaluation in boolean predicate OK
+/// {
+///   // This block will be executed
+/// }
+///
+/// EXPECT_FALSE(handle.IsValid());
+/// EXPECT_EQ(handle, FooHandle::Invalid());
+/// @endcode
+template <class IdType, class ValueType, ValueType InvalidValue>
+class OpaqueId
+{
+public:
+  OpaqueId() = default;
+  constexpr explicit OpaqueId(ValueType value);
+
+  static constexpr OpaqueId Invalid();
+
+  constexpr ValueType value() const;
+  constexpr bool      IsValid() const;
+  constexpr explicit  operator bool() const;
+  constexpr bool      operator!() const;
+
+  constexpr void SetValue(const ValueType& newValue);
+  constexpr void Clear();
+
+private:
+  ValueType value_{InvalidValue};
+};
+
+/// @brief Explicitly create an invalid ID.
+///
+/// Example:
+/// @code
+/// using FooId = etcpal::OpaqueId<FooIdType, int, -1>;
+/// auto invalid_id = FooId::Invalid();
+/// EXPECT_FALSE(invalid_id.IsValid());
+/// @endcode
+template <class IdType, class ValueType, ValueType InvalidValue>
+constexpr OpaqueId<IdType, ValueType, InvalidValue> OpaqueId<IdType, ValueType, InvalidValue>::Invalid()
+{
+  return OpaqueId();
+}
+
+/// @brief Explicitly create a valid ID based on a value.
+template <class IdType, class ValueType, ValueType InvalidValue>
+constexpr OpaqueId<IdType, ValueType, InvalidValue>::OpaqueId(ValueType value) : value_(value)
+{
+}
+
+/// @brief Get the underlying value from an ID.
+template <class IdType, class ValueType, ValueType InvalidValue>
+constexpr ValueType OpaqueId<IdType, ValueType, InvalidValue>::value() const
+{
+  return value_;
+}
+
+/// @brief Explicitly determine whether an ID is valid.
+template <class IdType, class ValueType, ValueType InvalidValue>
+constexpr bool OpaqueId<IdType, ValueType, InvalidValue>::IsValid() const
+{
+  return !(value_ == InvalidValue);
+}
+
+/// @brief Determine whether an ID is valid by testing as a boolean predicate.
+///
+/// Example:
+/// @code
+/// if (id)
+/// {
+///   // Do things if id is valid
+/// }
+/// else
+/// {
+///   // Do things if id is invalid
+/// }
+/// @endcode
+template <class IdType, class ValueType, ValueType InvalidValue>
+constexpr OpaqueId<IdType, ValueType, InvalidValue>::operator bool() const
+{
+  return IsValid();
+}
+
+/// @brief Determine whether an ID is not valid.
+template <class IdType, class ValueType, ValueType InvalidValue>
+constexpr bool OpaqueId<IdType, ValueType, InvalidValue>::operator!() const
+{
+  return !IsValid();
+}
+
+/// @brief Set a new underlying value for an ID.
+/// @param new_value The new value to set.
+template <class IdType, class ValueType, ValueType InvalidValue>
+constexpr void OpaqueId<IdType, ValueType, InvalidValue>::SetValue(const ValueType& new_value)
+{
+  value_ = new_value;
+}
+
+/// @brief Clear any valid value from an ID and set it back to the invalid value.
+/// @post value.IsValid() will return false.
+template <class IdType, class ValueType, ValueType InvalidValue>
+constexpr void OpaqueId<IdType, ValueType, InvalidValue>::Clear()
+{
+  value_ = InvalidValue;
+}
+
+/// @addtogroup etcpal_cpp_opaque_id
+/// @{
+
+/// @name OpaqueId relational operators
+/// @{
+
+template <class IdType, class ValueType, ValueType InvalidValue>
+constexpr bool operator==(const OpaqueId<IdType, ValueType, InvalidValue>& a,
+                          const OpaqueId<IdType, ValueType, InvalidValue>& b)
+{
+  return a.value() == b.value();
+}
+
+template <class IdType, class ValueType, ValueType InvalidValue>
+constexpr bool operator!=(const OpaqueId<IdType, ValueType, InvalidValue>& a,
+                          const OpaqueId<IdType, ValueType, InvalidValue>& b)
+{
+  return !(a == b);
+}
+
+template <class IdType, class ValueType, ValueType InvalidValue>
+constexpr bool operator<(const OpaqueId<IdType, ValueType, InvalidValue>& a,
+                         const OpaqueId<IdType, ValueType, InvalidValue>& b)
+{
+  return a.value() < b.value();
+}
+
+template <class IdType, class ValueType, ValueType InvalidValue>
+constexpr bool operator>(const OpaqueId<IdType, ValueType, InvalidValue>& a,
+                         const OpaqueId<IdType, ValueType, InvalidValue>& b)
+{
+  return b < a;
+}
+
+template <class IdType, class ValueType, ValueType InvalidValue>
+constexpr bool operator<=(const OpaqueId<IdType, ValueType, InvalidValue>& a,
+                          const OpaqueId<IdType, ValueType, InvalidValue>& b)
+{
+  return !(b < a);
+}
+
+template <class IdType, class ValueType, ValueType InvalidValue>
+constexpr bool operator>=(const OpaqueId<IdType, ValueType, InvalidValue>& a,
+                          const OpaqueId<IdType, ValueType, InvalidValue>& b)
+{
+  return !(a < b);
+}
+
+/// @}
+/// @}
+
+};  // namespace etcpal
+
+/// @cond std::hash specialization
+
+// Inject a new std::hash specialization for any template specialization of OpaqueId, so that
+// OpaqueIds can be used in hash-based containers (e.g. unordered_map and unordered_set) without
+// a user needing to create a hash specialization.
+//
+// The std::hash specialization simply passes through to a hash of the underlying value. If the
+// underlying value is not hashable, this specialization should simply be eliminated without a
+// compile error through SFINAE.
+namespace std
+{
+template <class IdType, class ValueType, ValueType InvalidValue>
+struct hash<etcpal::OpaqueId<IdType, ValueType, InvalidValue>>
+{
+  std::size_t operator()(const etcpal::OpaqueId<IdType, ValueType, InvalidValue>& id) const noexcept
+  {
+    return std::hash<ValueType>()(id.value());
+  }
+};
+};  // namespace std
+
+/// @endcond
+
+#endif  // ETCPAL_CPP_OPAQUE_ID_H_

--- a/include/etcpal/cpp/opaque_id.h
+++ b/include/etcpal/cpp/opaque_id.h
@@ -24,6 +24,7 @@
 #define ETCPAL_CPP_OPAQUE_ID_H_
 
 #include <functional>
+#include "etcpal/cpp/common.h"
 
 namespace etcpal
 {
@@ -126,8 +127,8 @@ public:
   constexpr explicit  operator bool() const;
   constexpr bool      operator!() const;
 
-  constexpr void SetValue(const ValueType& newValue);
-  constexpr void Clear();
+  ETCPAL_CONSTEXPR_14 void SetValue(const ValueType& newValue);
+  ETCPAL_CONSTEXPR_14 void Clear();
 
 private:
   ValueType value_{InvalidValue};
@@ -196,7 +197,7 @@ constexpr bool OpaqueId<IdType, ValueType, InvalidValue>::operator!() const
 /// @brief Set a new underlying value for an ID.
 /// @param new_value The new value to set.
 template <class IdType, class ValueType, ValueType InvalidValue>
-constexpr void OpaqueId<IdType, ValueType, InvalidValue>::SetValue(const ValueType& new_value)
+ETCPAL_CONSTEXPR_14_OR_INLINE void OpaqueId<IdType, ValueType, InvalidValue>::SetValue(const ValueType& new_value)
 {
   value_ = new_value;
 }
@@ -204,7 +205,7 @@ constexpr void OpaqueId<IdType, ValueType, InvalidValue>::SetValue(const ValueTy
 /// @brief Clear any valid value from an ID and set it back to the invalid value.
 /// @post value.IsValid() will return false.
 template <class IdType, class ValueType, ValueType InvalidValue>
-constexpr void OpaqueId<IdType, ValueType, InvalidValue>::Clear()
+ETCPAL_CONSTEXPR_14_OR_INLINE void OpaqueId<IdType, ValueType, InvalidValue>::Clear()
 {
   value_ = InvalidValue;
 }

--- a/tests/unit/cpp/CMakeLists.txt
+++ b/tests/unit/cpp/CMakeLists.txt
@@ -3,6 +3,7 @@
 etcpal_add_live_test(etcpal_cpp_unit_tests CXX
   test_error.cpp
   test_main.cpp
+  test_opaque_id.cpp
   test_uuid.cpp
 )
 

--- a/tests/unit/cpp/test_main.cpp
+++ b/tests/unit/cpp/test_main.cpp
@@ -23,6 +23,7 @@ extern "C" void run_all_tests(void)
 {
   RUN_TEST_GROUP(etcpal_cpp_error);
   RUN_TEST_GROUP(etcpal_cpp_uuid);
+  RUN_TEST_GROUP(etcpal_cpp_opaque_id);
 #if !ETCPAL_NO_OS_SUPPORT
 #if !DISABLE_EVENT_GROUP_TESTS
   RUN_TEST_GROUP(etcpal_cpp_event_group);

--- a/tests/unit/cpp/test_opaque_id.cpp
+++ b/tests/unit/cpp/test_opaque_id.cpp
@@ -54,6 +54,7 @@ TEST(etcpal_cpp_opaque_id, default_constructor_works)
   TEST_ASSERT_FALSE(id);
   TEST_ASSERT_FALSE(id.IsValid());
   TEST_ASSERT_TRUE(!id);
+  TEST_ASSERT_EQUAL(id.value(), -1);
 }
 
 TEST(etcpal_cpp_opaque_id, validators_work)
@@ -62,6 +63,7 @@ TEST(etcpal_cpp_opaque_id, validators_work)
   TEST_ASSERT_TRUE(id);
   TEST_ASSERT_TRUE(id.IsValid());
   TEST_ASSERT_FALSE(!id);
+  TEST_ASSERT_EQUAL(id.value(), 5);
 }
 
 TEST(etcpal_cpp_opaque_id, copy_constructor_works)

--- a/tests/unit/cpp/test_opaque_id.cpp
+++ b/tests/unit/cpp/test_opaque_id.cpp
@@ -1,0 +1,143 @@
+/******************************************************************************
+ * Copyright 2021 ETC Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************
+ * This file is a part of EtcPal. For more information, go to:
+ * https://github.com/ETCLabs/EtcPal
+ ******************************************************************************/
+
+#include "etcpal/cpp/opaque_id.h"
+#include "unity_fixture.h"
+
+#include <climits>
+#include <cstdint>
+#include <set>
+#include <unordered_set>
+
+struct TestIntIdType
+{
+};
+using TestIntId = etcpal::OpaqueId<TestIntIdType, int, -1>;
+
+// Traits should be evaluable at compile time
+static_assert(!TestIntId().IsValid(), "Default constructor and IsValid() should work in a constant expression");
+static_assert(!TestIntId(), "operator! should work in a constant expression");
+static_assert(TestIntId().value() == -1, "Value getter should work in a constant expression");
+static_assert(TestIntId(4), "Value constructor and operator bool should work in a constant expression");
+static_assert(TestIntId(4).value() == 4, "Value getter should work in a constant expression");
+
+extern "C" {
+TEST_GROUP(etcpal_cpp_opaque_id);
+
+TEST_SETUP(etcpal_cpp_opaque_id)
+{
+}
+
+TEST_TEAR_DOWN(etcpal_cpp_opaque_id)
+{
+}
+
+TEST(etcpal_cpp_opaque_id, default_constructor_works)
+{
+  TestIntId id;
+  TEST_ASSERT_FALSE(id);
+  TEST_ASSERT_FALSE(id.IsValid());
+  TEST_ASSERT_TRUE(!id);
+}
+
+TEST(etcpal_cpp_opaque_id, validators_work)
+{
+  TestIntId id(5);
+  TEST_ASSERT_TRUE(id);
+  TEST_ASSERT_TRUE(id.IsValid());
+  TEST_ASSERT_FALSE(!id);
+}
+
+TEST(etcpal_cpp_opaque_id, copy_constructor_works)
+{
+  TestIntId a(4);
+
+  TestIntId b(a);
+  TEST_ASSERT_EQUAL_INT(b.value(), 4);
+}
+
+TEST(etcpal_cpp_opaque_id, set_value_works)
+{
+  TestIntId id;
+  TEST_ASSERT_FALSE(id.IsValid());
+  id.SetValue(10);
+  TEST_ASSERT_TRUE(id.IsValid());
+  TEST_ASSERT_EQUAL(id.value(), 10);
+}
+
+TEST(etcpal_cpp_opaque_id, clear_works)
+{
+  TestIntId id(10);
+  TEST_ASSERT_TRUE(id.IsValid());
+  id.Clear();
+  TEST_ASSERT_FALSE(id.IsValid());
+  TEST_ASSERT_EQUAL(id.value(), -1);
+}
+
+TEST(etcpal_cpp_opaque_id, std_set_works)
+{
+  std::set<TestIntId> ids;
+  ids.insert(TestIntId());
+  ids.insert(TestIntId(1));
+
+  TEST_ASSERT_EQUAL(ids.size(), 2u);
+
+  auto set_it = ids.begin();
+  TEST_ASSERT_EQUAL(set_it->value(), -1);
+  ++set_it;
+  TEST_ASSERT_EQUAL(set_it->value(), 1);
+}
+
+TEST(etcpal_cpp_opaque_id, std_hash_works)
+{
+  std::unordered_set<TestIntId> ids;
+  ids.insert(TestIntId());
+  ids.insert(TestIntId(1));
+
+  TEST_ASSERT_EQUAL(ids.size(), 2u);
+}
+
+struct TestUint8IdType
+{
+};
+using TestUint8Id = etcpal::OpaqueId<TestUint8IdType, uint8_t, UINT8_MAX>;
+
+TEST(etcpal_cpp_opaque_id, uint8_id_works)
+{
+  TestUint8Id id;
+  TEST_ASSERT_FALSE(id.IsValid());
+  TEST_ASSERT_EQUAL(id.value(), UINT8_MAX);
+
+  TestUint8Id id2(0);
+  TEST_ASSERT_TRUE(id2.IsValid());
+  TEST_ASSERT_EQUAL(id2.value(), 0u);
+}
+
+TEST_GROUP_RUNNER(etcpal_cpp_opaque_id)
+{
+  RUN_TEST_CASE(etcpal_cpp_opaque_id, default_constructor_works);
+  RUN_TEST_CASE(etcpal_cpp_opaque_id, validators_work);
+  RUN_TEST_CASE(etcpal_cpp_opaque_id, copy_constructor_works);
+  RUN_TEST_CASE(etcpal_cpp_opaque_id, set_value_works);
+  RUN_TEST_CASE(etcpal_cpp_opaque_id, clear_works);
+  RUN_TEST_CASE(etcpal_cpp_opaque_id, std_set_works);
+  RUN_TEST_CASE(etcpal_cpp_opaque_id, std_hash_works);
+  RUN_TEST_CASE(etcpal_cpp_opaque_id, uint8_id_works);
+}
+}


### PR DESCRIPTION
This module contains etcpal::OpaqueId, a type-safe handle identifier. Accompanied by tests and docs.