### PR TITLE
QOL enhancements for C++ Thread and Logger

### DIFF
--- a/include/etcpal/cpp/log.h
+++ b/include/etcpal/cpp/log.h
@@ -280,6 +280,12 @@ public:
   Logger& SetSyslogProcId(const char* proc_id) noexcept;
   Logger& SetSyslogProcId(const std::string& proc_id) noexcept;
   Logger& SetSyslogProcId(int proc_id) noexcept;
+
+  Logger& SetThreadPriority(unsigned int priority) noexcept;
+  Logger& SetThreadStackSize(unsigned int stack_size) noexcept;
+  Logger& SetThreadName(const char* name) noexcept;
+  Logger& SetThreadName(const std::string& name) noexcept;
+  Logger& SetThreadPlatformData(void* platform_data) noexcept;
   /// @}
 
 private:
@@ -624,6 +630,51 @@ inline Logger& Logger::SetSyslogProcId(const char* proc_id) noexcept
 inline Logger& Logger::SetSyslogProcId(const std::string& proc_id) noexcept
 {
   SetSyslogProcId(proc_id.c_str());
+  return *this;
+}
+
+/// @brief Set the priority of the log dispatch thread.
+/// @see etcpal::Thread::SetPriority()
+/// @note If the dispatch policy is LogDispatchPolicy::Direct, this has no effect.
+Logger& Logger::SetThreadPriority(unsigned int priority) noexcept
+{
+  thread_.SetPriority(priority);
+  return *this;
+}
+
+/// @brief Set the stack size of the log dispatch thread.
+/// @see etcpal::Thread::SetStackSize()
+/// @note If the dispatch policy is LogDispatchPolicy::Direct, this has no effect.
+Logger& Logger::SetThreadStackSize(unsigned int stack_size) noexcept
+{
+  thread_.SetStackSize(stack_size);
+  return *this;
+}
+
+/// @brief Set the name of the log dispatch thread.
+/// @see etcpal::Thread::SetName()
+/// @note If the dispatch policy is LogDispatchPolicy::Direct, this has no effect.
+Logger& Logger::SetThreadName(const char* name) noexcept
+{
+  thread_.SetName(name);
+  return *this;
+}
+
+/// @brief Set the name of the log dispatch thread.
+/// @see etcpal::Thread::SetName()
+/// @note If the dispatch policy is LogDispatchPolicy::Direct, this has no effect.
+Logger& Logger::SetThreadName(const std::string& name) noexcept
+{
+  thread_.SetName(name);
+  return *this;
+}
+
+/// @brief Set the platform-specific parameter data of the log dispatch thread.
+/// @see etcpal::Thread::SetName()
+/// @note If the dispatch policy is LogDispatchPolicy::Direct, this has no effect.
+Logger& Logger::SetThreadPlatformData(void* platform_data) noexcept
+{
+  thread_.SetPlatformData(platform_data);
   return *this;
 }
 

--- a/include/etcpal/cpp/log.h
+++ b/include/etcpal/cpp/log.h
@@ -670,7 +670,7 @@ Logger& Logger::SetThreadName(const std::string& name) noexcept
 }
 
 /// @brief Set the platform-specific parameter data of the log dispatch thread.
-/// @see etcpal::Thread::SetName()
+/// @see etcpal::Thread::SetPlatformData()
 /// @note If the dispatch policy is LogDispatchPolicy::Direct, this has no effect.
 Logger& Logger::SetThreadPlatformData(void* platform_data) noexcept
 {

--- a/tests/unit/cpp/test_thread.cpp
+++ b/tests/unit/cpp/test_thread.cpp
@@ -42,7 +42,28 @@ TEST(etcpal_cpp_thread, default_constructor_works)
   TEST_ASSERT_FALSE(thrd.Join().IsOk());
 }
 
-TEST(etcpal_cpp_thread, constructor_works_no_args)
+TEST(etcpal_cpp_thread, params_constructor_works)
+{
+  etcpal::Thread thrd(42u, 1234u, "test_thread", nullptr);
+  TEST_ASSERT_EQUAL_UINT(thrd.priority(), 42u);
+  TEST_ASSERT_EQUAL_UINT(thrd.stack_size(), 1234u);
+  TEST_ASSERT_EQUAL_STRING(thrd.name(), "test_thread");
+  TEST_ASSERT_EQUAL_PTR(thrd.platform_data(), nullptr);
+
+  // Now test a thread that actually runs
+  etcpal::Thread thrd2(ETCPAL_THREAD_DEFAULT_PRIORITY, ETCPAL_THREAD_DEFAULT_STACK, "test_thread");
+  bool           thread_ran = false;
+  thrd2.Start([&]() {
+    etcpal::Thread::Sleep(1);
+    thread_ran = true;
+  });
+  TEST_ASSERT_TRUE(thrd2.joinable());
+  TEST_ASSERT_TRUE(thrd2.Join().IsOk());
+  TEST_ASSERT_FALSE(thrd2.joinable());
+  TEST_ASSERT_TRUE(thread_ran);
+}
+
+TEST(etcpal_cpp_thread, thread_constructor_works_no_args)
 {
   bool           thread_ran = false;
   etcpal::Thread thrd([&]() {
@@ -55,7 +76,7 @@ TEST(etcpal_cpp_thread, constructor_works_no_args)
   TEST_ASSERT_TRUE(thread_ran);
 }
 
-TEST(etcpal_cpp_thread, constructor_works_with_args)
+TEST(etcpal_cpp_thread, thread_constructor_works_with_args)
 {
   bool           thread_ran = false;
   etcpal::Thread thrd(
@@ -236,8 +257,9 @@ TEST(etcpal_cpp_thread, get_os_handle_works)
 TEST_GROUP_RUNNER(etcpal_cpp_thread)
 {
   RUN_TEST_CASE(etcpal_cpp_thread, default_constructor_works);
-  RUN_TEST_CASE(etcpal_cpp_thread, constructor_works_no_args);
-  RUN_TEST_CASE(etcpal_cpp_thread, constructor_works_with_args);
+  RUN_TEST_CASE(etcpal_cpp_thread, params_constructor_works);
+  RUN_TEST_CASE(etcpal_cpp_thread, thread_constructor_works_no_args);
+  RUN_TEST_CASE(etcpal_cpp_thread, thread_constructor_works_with_args);
   RUN_TEST_CASE(etcpal_cpp_thread, start_works_no_args);
   RUN_TEST_CASE(etcpal_cpp_thread, start_works_with_args);
   RUN_TEST_CASE(etcpal_cpp_thread, member_function);


### PR DESCRIPTION
- Add Thread constructor that takes thread params
  + Note: This requires a disambiguating `enable_if` template parameter on the existing Thread template constructor to avoid ambiguous overload resolution
- Logger: Add methods to set params on the underlying thread for Queued dispatch