### PR TITLE
Add missing 'inline' modifiers to etcpal::Logger functions

### DIFF
--- a/include/etcpal/cpp/log.h
+++ b/include/etcpal/cpp/log.h
@@ -636,7 +636,7 @@ inline Logger& Logger::SetSyslogProcId(const std::string& proc_id) noexcept
 /// @brief Set the priority of the log dispatch thread.
 /// @see etcpal::Thread::SetPriority()
 /// @note If the dispatch policy is LogDispatchPolicy::Direct, this has no effect.
-Logger& Logger::SetThreadPriority(unsigned int priority) noexcept
+inline Logger& Logger::SetThreadPriority(unsigned int priority) noexcept
 {
   thread_.SetPriority(priority);
   return *this;
@@ -645,7 +645,7 @@ Logger& Logger::SetThreadPriority(unsigned int priority) noexcept
 /// @brief Set the stack size of the log dispatch thread.
 /// @see etcpal::Thread::SetStackSize()
 /// @note If the dispatch policy is LogDispatchPolicy::Direct, this has no effect.
-Logger& Logger::SetThreadStackSize(unsigned int stack_size) noexcept
+inline Logger& Logger::SetThreadStackSize(unsigned int stack_size) noexcept
 {
   thread_.SetStackSize(stack_size);
   return *this;
@@ -654,7 +654,7 @@ Logger& Logger::SetThreadStackSize(unsigned int stack_size) noexcept
 /// @brief Set the name of the log dispatch thread.
 /// @see etcpal::Thread::SetName()
 /// @note If the dispatch policy is LogDispatchPolicy::Direct, this has no effect.
-Logger& Logger::SetThreadName(const char* name) noexcept
+inline Logger& Logger::SetThreadName(const char* name) noexcept
 {
   thread_.SetName(name);
   return *this;
@@ -663,7 +663,7 @@ Logger& Logger::SetThreadName(const char* name) noexcept
 /// @brief Set the name of the log dispatch thread.
 /// @see etcpal::Thread::SetName()
 /// @note If the dispatch policy is LogDispatchPolicy::Direct, this has no effect.
-Logger& Logger::SetThreadName(const std::string& name) noexcept
+inline Logger& Logger::SetThreadName(const std::string& name) noexcept
 {
   thread_.SetName(name);
   return *this;
@@ -672,7 +672,7 @@ Logger& Logger::SetThreadName(const std::string& name) noexcept
 /// @brief Set the platform-specific parameter data of the log dispatch thread.
 /// @see etcpal::Thread::SetPlatformData()
 /// @note If the dispatch policy is LogDispatchPolicy::Direct, this has no effect.
-Logger& Logger::SetThreadPlatformData(void* platform_data) noexcept
+inline Logger& Logger::SetThreadPlatformData(void* platform_data) noexcept
 {
   thread_.SetPlatformData(platform_data);
   return *this;


### PR DESCRIPTION
These were failing compilation because they were not marked 'inline'.