### PR TITLE
Fix lwip interface enumerate with single interface

### DIFF
--- a/src/os/lwip/etcpal/os_netint.c
+++ b/src/os/lwip/etcpal/os_netint.c
@@ -104,8 +104,10 @@ etcpal_error_t os_enumerate_interfaces(CachedNetintInfo* cache)
       break;
     }
 #else
+#ifndef LWIP_SINGLE_NETIF
     if (num_static_netints >= ETCPAL_EMBOS_MAX_NETINTS)
       break;
+#endif
 #endif
     copy_interface_info_v4(lwip_netif, &static_netints[num_static_netints++]);
 #endif


### PR DESCRIPTION
Under lwip, os_enumerate_interfaces() would fail if only a single interface is enabled by define.
In this situation NETIF_FOREACH define evaluates to an if statement, which results in the interface count limit check attempting to exit this if statement with a break.
As the limit check is redundant for a single interface, it is defined out.